### PR TITLE
Clickable buttons

### DIFF
--- a/jspwiki-war/src/main/scripts/wiki/Wiki.js
+++ b/jspwiki-war/src/main/scripts/wiki/Wiki.js
@@ -62,25 +62,26 @@ var Wiki = {
 
 	version: "haddock04",  //used to validate compatible preference cookies
 
-	initialize: function () {
+	initialize: function(){
 
 		var wiki = this,
 			behavior = new Behavior();
+
 		wiki.add = behavior.add.bind(behavior);
 		wiki.once = behavior.once.bind(behavior);
 		wiki.update = behavior.update.bind(behavior);
 
 
 		// add core jspwiki behaviors; needed to support the default template jsp's
-		wiki.add("body", wiki.caniuse)
+		wiki.add( "body", wiki.caniuse )
 
-			.add("[accesskey]", Accesskey)
+			.add( "[accesskey]", Accesskey )
 
 			//toggle effect:  toggle .active class on this element when clicking toggle element
 			//.add("[data-toggle]", "onToggle", {attr:"data-toggle"})
-			.add("[data-toggle]", function (element) {
+			.add( "[data-toggle]", function(element){
 
-				element.onToggle(element.get("data-toggle"), function (isActive) {
+				element.onToggle( element.get("data-toggle"), function(isActive){
 					var pref = element.get("data-toggle-pref");
 					if (pref) {
 						wiki.prefs.set(pref, isActive ? "active" : "");
@@ -91,14 +92,14 @@ var Wiki = {
 			//generate modal confirmation boxes, eg prompting to execute
 			//an unrecoverable action such as deleting a page or attachment
 			//.add("[data-modal]", "onModal", {attr:"data-modal"})
-			.add("[data-modal]", function (element) {
-				element.onModal(element.get("data-modal"));
+			.add( "[data-modal]", function(element){
+				element.onModal( element.get("data-modal") );
 			})
 
 			//hover effects: show/hide this element when hovering over the parent element
 			//.add("[data-toggle]", "onHover", {attr:"data-hover-parent"})
-			.add("[data-hover-parent]", function (element) {
-				element.onHover(element.get("data-hover-parent"));
+			.add( "[data-hover-parent]", function(element){
+				element.onHover( element.get("data-hover-parent") );
 			})
 
 			// Click effect: Similar to hover effect, but triggered on click of an element (e.g. for searchbox)
@@ -138,8 +139,8 @@ var Wiki = {
 
 			//resize the "data-resize" elements when dragging this element
 			//.add( "[data-resize]", wiki.resizer.bind(wiki) )
-			.add("[data-resize]", function (element) {
-				wiki.resizer(element, $$(element.get("data-resize")));
+			.add( "[data-resize]", function(element){
+				wiki.resizer(element, $$(element.get("data-resize")) );
 			})
 
 			//add header scroll-up/down effect
@@ -151,46 +152,46 @@ var Wiki = {
 			})
 
 			//highlight previous search query retreived from a cookie or referrer page
-			.add(".page-content", function (element) {
+			.add( ".page-content", function(element){
 
 				var previousQuery = "PrevQuery";
 
-				HighlightQuery(element, wiki.prefs.get(previousQuery));
+				HighlightQuery( element, wiki.prefs.get(previousQuery) );
 				wiki.prefs.erase(previousQuery);
 
 			})
 
 			//activate quick navigation searchbox
-			.add(".searchbox .dropdown-menu", function (element) {
+			.add( ".searchbox .dropdown-menu", function(element){
 
 				var recentSearch = "RecentSearch", prefs = wiki.prefs;
 
 				//activate Recent Searches functionality
-				new wiki.Recents(element, {
+				new wiki.Recents( element, {
 					items: prefs.get(recentSearch),
-					onChange: function (items) {
+					onChange: function( items ){
 						items ? prefs.set(recentSearch, items) : prefs.erase(recentSearch);
 					}
 				});
 
 				//activate Quick Navigation functionality
 				new wiki.Findpages(element, {
-					rpc: function (value, callback) {
+					rpc: function(value, callback){
 						wiki.jsonrpc("/search/pages", [value, 16], callback);
 					},
 					toUrl: wiki.toUrl.bind(wiki),
-					allowClone: function () {
-						return /view|preview|info|attach/.test(wiki.Context);
+					allowClone: function(){
+						return /view|preview|info|attach/.test( wiki.Context );
 					}
 				});
 			})
 
 			//activate ajax search routines on Search.jsp
-			.add("#searchform2", function (form) {
+			.add( "#searchform2", function(form){
 
-				wiki.search = new wiki.Search(form, {
+				wiki.search = new wiki.Search( form, {
 					xhrURL: wiki.XHRSearch,
-					onComplete: function () {
+					onComplete: function(){
 						//console.log(form.query.get("value"));
 						wiki.prefs.set("PrevQuery", form.query.get("value"));
 					}
@@ -198,9 +199,9 @@ var Wiki = {
 			})
 
 			//activate attachment upload routines
-			.add("#files", Form.File, {
+			.add( "#files", Form.File, {
 				max: 8,
-				rpc: function (progressid, callback) {
+				rpc: function(progressid, callback){
 					//console.log("progress", progressid);
 					wiki.jsonrpc("/progressTracker", [progressid], callback);
 				}
@@ -214,30 +215,17 @@ var Wiki = {
 	},
 
 
-	caniuse: function (body) {
+	caniuse: function( body ){
 
 		//support for flexbox is broken in IE, do it the hard-way - ugh.
 
 		var isIE11 = !(window.ActiveXObject) && "ActiveXObject" in window;
 		var isIE9or10 = "ActiveXObject" in window;
 
-		body.ifClass(!(isIE11 || isIE9or10), "can-flex");
+		body.ifClass( !( isIE11 || isIE9or10 ) , "can-flex");
+
 	},
 
-	listenForCloseClick: function (element) {
-		var wiki = this;
-		jq$('body').click(function (event) {
-			var target = $(event.target);
-			if (!element.is(target)) {
-				element.removeClass('open');
-				wiki.stopListeningForCloseClick();
-			}
-		})
-	},
-
-	stopListeningForCloseClick: function () {
-		jq$('body').unbind('click');
-	},
 
 	/*
 	Function: domready
@@ -247,7 +235,7 @@ var Wiki = {
 		- when the "referrer" url (previous page) contains a "section=" parameter,
 		  scroll the wiki page to the right section
 	*/
-	domready: function () {
+	domready: function(){
 
 		var wiki = this;
 
@@ -262,16 +250,16 @@ var Wiki = {
 
 		//Object.each(wiki.prefs.hash, function(item,key){ console.log("PREFS  ",key,"=>",item); });
 
-		if (wiki.version != wiki.prefs.get("version")) {
+		if( wiki.version != wiki.prefs.get("version") ){
 			wiki.prefs.empty();
 			wiki.prefs.set("version", wiki.version);
 		}
 
 		//The initial Sidebar will be active depending on a cookie state.
 		//However, for small screen,  the default state will be hidden.
-		wiki.media("(min-width:768px)", function (screenIsLarge) {
+		wiki.media("(min-width:768px)", function( screenIsLarge ){
 
-			if (!screenIsLarge) {
+			if(!screenIsLarge){
 				$$(".content")[0].removeClass("active"); //always hide sidebar on pageload for narrow screens
 			}
 
@@ -279,14 +267,14 @@ var Wiki = {
 
 		//wiki.url = null;  //CHECK:  why this is needed?
 		//console.log( wiki.prefs.get("SectionEditing") , wiki.EditPermission ,wiki.Context );
-		if (wiki.prefs.get("SectionEditing") && wiki.EditPermission && (wiki.Context != "preview")) {
+		if( wiki.prefs.get("SectionEditing") && wiki.EditPermission && (wiki.Context != "preview") ){
 
-			wiki.addEditLinks(wiki.toUrl(wiki.PageName, true));
+			wiki.addEditLinks( wiki.toUrl( wiki.PageName, true ) );
 
 		}
 
 		//console.log( "section", document.referrer, document.referrer.match( /\&section=(\d+)$/ ) );
-		wiki.scrollTo((document.referrer.match(/\&section=(\d+)$/) || [, -1])[1]);
+		wiki.scrollTo( ( document.referrer.match( /\&section=(\d+)$/ ) || [,-1])[1] );
 
 		// initialize all registered behaviors
 		wiki.update();
@@ -303,17 +291,15 @@ var Wiki = {
 	Function: media query event handler
 		Catch media-query changes  (eg screen width,  portrait/landscape changes,  etc...
 	*/
-	media: function (query, callback) {
+	media: function(query, callback){
 
-		function queryChanged(event) {
-			callback(event.matches);
-		}
+		function queryChanged( event ){ callback( event.matches ); }
 
-		if (/*window.*/ matchMedia) {
+		if( /*window.*/ matchMedia ){
 
-			var mediaQueryList = matchMedia(query);
-			mediaQueryList.addListener(queryChanged);
-			queryChanged(mediaQueryList);
+			var mediaQueryList = matchMedia( query );
+			mediaQueryList.addListener( queryChanged );
+			queryChanged( mediaQueryList );
 		}
 
 	},
@@ -331,7 +317,7 @@ var Wiki = {
 	(end)
 
 	*/
-	yoyo: function (header) {
+	yoyo: function( header ){
 
 		var height = "offsetHeight",
 			scrollY,
@@ -342,11 +328,11 @@ var Wiki = {
 			spacer = "div".slick().inject(header, "before"),
 			busy;
 
-		function update() {
+		function update(){
 
 			scrollY = window.getScroll().y;
 
-			spacer.style.paddingTop = header[height] + "px"; //update after window resize
+			spacer.style.paddingTop = header[height]+"px"; //update after window resize
 
 			// Limit scroll top to counteract iOS / OSX bounce.
 			scrollY = scrollY.limit(0, window.getScrollSize().y - window.getSize().y);
@@ -360,14 +346,14 @@ var Wiki = {
 			busy = false;
 		}
 
-		function handleEvent() {
-			if (!busy) {
+		function handleEvent(){
+			if(!busy){
 				busy = true;
-				requestAnimationFrame(update);
+				requestAnimationFrame( update );
 			}
 		}
 
-		window.addEvents({scroll: handleEvent, resize: handleEvent});
+		window.addEvents({ scroll: handleEvent, resize: handleEvent });
 		update(); //first run: set height of the spacer
 
 	},
@@ -387,7 +373,7 @@ var Wiki = {
 		popstate event is 'bubbled' up the DOM tree.
 
 	*/
-	popstate: function () {
+	popstate: function(){
 
 		var target = $(location.hash.slice(1)),
 			events,
@@ -396,13 +382,13 @@ var Wiki = {
 		//console.log( popstate, location.hash, target );
 
 		//only send popstate events to targets within the main page; eg not sidebar
-		if (target && target.getParent(".page-content")) {
+		if( target && target.getParent(".page-content") ){
 
-			while (!target.hasClass("page-content")) {
+			while( !target.hasClass("page-content") ){
 
 				events = target.retrieve("events"); //mootools specific - to read registered events on elements
 
-				if (events && events[popstate]) {
+				if( events && events[popstate] ){
 
 					target.fireEvent(popstate);
 
@@ -414,20 +400,20 @@ var Wiki = {
 		}
 	},
 
-	autofocus: function () {
+	autofocus: function(){
 
 		var els, element;
 
-		if (!("autofocus" in document.createElement("input"))) {
+		if( !("autofocus" in document.createElement("input") ) ){
 			// editor/plain.jsp  textarea#wikiText
 			// login.jsp         input#j_username
 			// prefs/prefs       input#assertedName
 			// find              input#query2
 			els = $$("input[autofocus=autofocus], textarea[autofocus=autofocus]");
-			while (els[0]) {
+			while( els[0] ){
 				element = els.shift();
 				//console.log("autofocus", element, element.autofocus, element.isVisible(), element.offsetWidth, element.offsetHeight, "$", element.getStyle("display"), "$");
-				if (element.isVisible()) {
+				if( element.isVisible() ){
 					element.focus();
 					return;
 				}
@@ -452,13 +438,13 @@ var Wiki = {
 		* wikiApplicationName
 		* wikiEditPermission
 	*/
-	meta: function () {
+	meta: function(){
 
 		var url,
 			wiki = this,
 			host = location.host;
 
-		$$("meta[name^=wiki]").each(function (el) {
+		$$("meta[name^=wiki]").each( function(el){
 			wiki[el.get("name").slice(4)] = el.get("content") || "";
 		});
 
@@ -476,19 +462,19 @@ var Wiki = {
 		Parse special wikipages such ase MoreMenu, HomeMenu
 		and format them as bootstrap compatible dropdown menus.
 	*/
-	dropdowns: function () {
+	dropdowns: function(){
 
-		$$("ul.dropdown-menu > li > ul").each(function (ul) {
+		$$( "ul.dropdown-menu > li > ul" ).each( function(ul){
 
 			var li, parentLi = ul.getParent();
 
-			while ((li = ul.getFirst("li"))) {
+			while( (li = ul.getFirst("li")) ){
 
-				if (li.innerHTML.trim() == "----") {
+				if( li.innerHTML.trim() == "----" ){
 
 					li.addClass("divider");
 
-				} else if (!li.getFirst() || !li.getFirst("a")) {
+				} else if( !li.getFirst() || !li.getFirst("a") ){
 
 					li.addClass("dropdown-header");
 
@@ -505,15 +491,15 @@ var Wiki = {
 			  Each <p> becomes a set of <li>, one for each link
 			  The block is terminated with a divider, if more <p>'s are coming
 		*/
-		$$("ul.dropdown-menu > li.more-menu > p").each(function (element) {
+		$$( "ul.dropdown-menu > li.more-menu > p" ).each( function(element){
 
 			var parentLi = element.getParent();
 
-			element.getElements('a').each(function (link) {
-				["li", [link]].slick().inject(parentLi, "before");
+			element.getElements('a').each( function(link){
+				["li",[link]].slick().inject(parentLi, "before");
 			});
-			if (element.getNext("p *,hr")) {
-				"li.divider".slick().inject(parentLi, "before");
+			if( element.getNext("p *,hr") ){
+				"li.divider".slick().inject(parentLi, "before") ;
 			}
 			element.dispose();
 
@@ -525,7 +511,7 @@ var Wiki = {
 	Function: getSections
 		Returns the list of all section headers, excluding the header of the Table Of Contents.
 	*/
-	getSections: function () {
+	getSections: function(){
 
 		return $$(".page-content [id^=section]:not(#section-TOC)");
 
@@ -536,13 +522,13 @@ var Wiki = {
 		Scrolls the page to the section previously being edited - if any
 		Section counting starts at 1??
 	*/
-	scrollTo: function (index) {
+	scrollTo: function( index ){
 
 		//console.log("Scroll to section ", index, ", Number of sections:", this.getSections().length );
 		var element = this.getSections()[index];
 
-		if (element) {
-			location.replace("#" + element.get("id"));
+		if( element ){
+			location.replace( "#" + element.get("id") );
 		}
 
 	},
@@ -552,10 +538,10 @@ var Wiki = {
 		Convert a wiki pagename to a full wiki-url.
 		Use the correct url template: view(default), edit-url or clone-url
 	*/
-	toUrl: function (pagename, isEdit, isClone) {
+	toUrl: function(pagename, isEdit, isClone){
 
 		var urlTemplate = isClone ? this.CloneUrl : isEdit ? this.EditUrl : this.PageUrl;
-		return urlTemplate.replace(/%23%24%25/, this.cleanPageName(pagename));
+		return urlTemplate.replace(/%23%24%25/, this.cleanPageName(pagename) );
 
 	},
 
@@ -563,10 +549,10 @@ var Wiki = {
 	Property: toPageName
 		Parse a wiki-url and return the corresponding wiki pagename
 	*/
-	toPageName: function (url) {
+	toPageName: function(url){
 
 		var s = this.PageUrl.escapeRegExp().replace(/%23%24%25/, "(.+)");
-		return (url.match(RegExp(s)) || [0, false])[1];
+		return ( url.match( RegExp(s) ) || [0, false] )[1];
 
 	},
 
@@ -576,7 +562,7 @@ var Wiki = {
 		Trim all whitespace, allow letters, digits and punctuation chars: ()&+, -=._$
 		Mirror of org.apache.wiki.parser.MarkupParser.cleanPageName()
 	*/
-	cleanPageName: function (pagename) {
+	cleanPageName: function( pagename ){
 
 		//\w is short for [A-Z_a-z0-9_]
 		return pagename.clean().replace(/[^\w\u00C0-\u1FFF\u2800-\uFFFD\(\)&\+,\-=\.\$ ]/g, "");
@@ -589,15 +575,15 @@ var Wiki = {
 		FFS: should better move server side
 		FFS: add section #hash to automatically go back to the section being edited
 	*/
-	addEditLinks: function (url) {
+	addEditLinks: function( url ){
 
 		var description = "quick.edit".localize();
 
 		url = url + (url.contains("?") ? "&" : "?") + "section=";
 
-		this.getSections().each(function (element, index) {
+		this.getSections().each( function(element, index){
 
-			element.grab("a.editsection".slick({html: description, href: url + index}));
+			element.grab("a.editsection".slick({ html: description, href: url + index }));
 
 		});
 
@@ -612,34 +598,32 @@ var Wiki = {
 
 		EG: tabcompletion, smartpairs, autosuggest, livepreview, previewcolumn. editor-type
 	*/
-	configPrefs: function (form, onChangeFn) {
+	configPrefs: function( form, onChangeFn ){
 
 		var wiki = this;
 
-		function onCheck() {
+		function onCheck(){
 
 			var cmd = this.getAttribute("data-cmd"),
 				isChecked = this.checked;
 
 			wiki.toggleLivePreview(form, cmd, isChecked);
 			wiki.prefs.set(cmd, isChecked);  //persist in the pref cookie
-			if (onChangeFn) {
-				onChangeFn(cmd, isChecked);
-			}
+			if( onChangeFn ){ onChangeFn(cmd, isChecked); }
 
 		}
 
 		//Handle all configuration checkboxes
-		form.getElements("[type=checkbox][data-cmd]").each(function (el) {
+		form.getElements("[type=checkbox][data-cmd]").each( function( el ){
 
 			el.checked = !!wiki.prefs.get(el.getAttribute("data-cmd"));
-			el.addEvent("click", onCheck);
+			el.addEvent("click", onCheck );
 			onCheck.apply(el);
 
 		});
 
 		//Persist the selected editor type in the pref cookie
-		form.getElements("a.editor-type").addEvent("click", function () {
+		form.getElements("a.editor-type").addEvent("click", function(){
 
 			wiki.prefs.set("editor", this.get("text"));
 
@@ -648,14 +632,14 @@ var Wiki = {
 	},
 
 
-	toggleLivePreview: function (container, cmd, state) {
+	toggleLivePreview: function( container, cmd, state ){
 
-		if (cmd.test(/livepreview|previewcolumn/)) {
+		if( cmd.test( /livepreview|previewcolumn/ ) ){
 
 			var previewcontainer = container.getElement(".edit-area").ifClass(state, cmd),
 				ajaxpreview = container.getElement(".ajaxpreview");
 
-			if (cmd == "livepreview") {
+			if( cmd == "livepreview" ){
 
 				//disable the previewcolumn toolbar cmd checkbox
 				container.getElement("[data-cmd=previewcolumn]").disabled = !state;
@@ -681,38 +665,20 @@ var Wiki = {
 					div.col-50.ajaxpreview
 				*/
 
-				if (!state) {
-					previewcontainer = previewcontainer.getParent();
-				}
+				if( !state ){ previewcontainer = previewcontainer.getParent(); }
 				previewcontainer.grab(ajaxpreview);
 
 			}
-
-
-			// Auto size editor and live preview window
-			var editPanes = jq$('.editor');
-			for (var i = 0; i < editPanes.length; i++) {
-				var editor = jq$(editPanes[i]);
-				if (editor.is('#editorarea')) continue;
-				editor.autosize();
-				editor.trigger('autosize.resize');
-			}
-
-			jq$(ajaxpreview).height(jq$(editPanes[0]).height());
 		}
-
-
 	},
 
-	getXHRPreview: function (getContent, previewElement) {
+	getXHRPreview: function( getContent, previewElement ){
 
 		var wiki = this,
 			loading = "loading",
-			preview = function (p) {
-				previewElement.removeClass(loading).set("text", p);
-			};
+			preview = function(p){ previewElement.removeClass(loading).set("text", p);};
 
-		return (function () {
+		return (function(){
 
 			previewElement.addClass(loading);
 
@@ -721,11 +687,11 @@ var Wiki = {
 				data: {
 					htmlPageText: getContent()
 				},
-				onSuccess: function (responseText) {
-					preview(responseText.trim());
+				onSuccess: function(responseText){
+					preview( responseText.trim() );
 				},
-				onFailure: function (e) {
-					preview("Sorry, HTML to Wiki Markup conversion failed :=() " + e);
+				onFailure: function(e){
+					preview( "Sorry, HTML to Wiki Markup conversion failed :=() " + e );
 				}
 			}).send();
 
@@ -758,41 +724,31 @@ var Wiki = {
 	div.resizer[data-resize=".pagecontent"] => for add-comment sections
 	div.resizer[data-resize=".ajaxpreview,.snipeable"][data-pref=editorHeight]
 	*/
-	resizer: function (handle, targets, dragCallback) {
+	resizer: function( handle, targets, dragCallback ){
 
 		var pref = handle.get("data-pref"),
 			prefs = this.prefs,
 			target;
 
-		function showDragState(add) {
-			handle.ifClass(add, "dragging");
-		}
+		function showDragState(add){ handle.ifClass(add, "dragging"); }
 
-		if (!targets[0]) {
-			return;
-		}
+		if( !targets[0] ){ return; }
 
 		//set the initial size of the targets
-		if (pref) {
-			targets.setStyle("height", prefs.get(pref) || 300);
+		if( pref ){
+			targets.setStyle("height", prefs.get(pref) || 300 );
 		}
 
 		target = targets.pop();
 
 		target.makeResizable({
 			handle: handle,
-			modifiers: {x: null},
-			onDrag: function () {
+			modifiers: { x: null },
+			onDrag: function(){
 				var h = this.value.now.y;
-				if (pref) {
-					prefs.set(pref, h);
-				}
-				if (targets) {
-					targets.setStyle("height", h);
-				}
-				if (dragCallback) {
-					dragCallback(h);
-				}
+				if( pref ){ prefs.set(pref, h); }
+				if( targets ){ targets.setStyle("height", h); }
+				if( dragCallback ){ dragCallback(h); }
 			},
 			onBeforeStart: showDragState.pass(true),
 			onComplete: showDragState.pass(false),
@@ -802,31 +758,31 @@ var Wiki = {
 	},
 
 
-	pageDialog: function (caption, method) {
+	pageDialog: function( caption, method ){
 
 		var wiki = this;
 
-		return [Dialog.Selection, {
+		return [ Dialog.Selection, {
 
 			caption: caption,
 
-			onOpen: function (dialog) {
+			onOpen: function( dialog ){
 
 				var key = dialog.getValue();
 
 				//if empty link, than fetch list of attachments of the open page
-				if (!key || (key.trim() == '')) {
+				if( !key || (key.trim()=='') ){
 
 					key = wiki.PageName + "/";
 
 				}
 
-				wiki.jsonrpc(method, [key, 30], function (result) {
+				wiki.jsonrpc( method, [key, 30], function( result ){
 
 					//console.log("jsonrpc result", result, !!result[0] );
-					if (result[0] /* length > 0 */) {
+					if( result[0] /* length > 0 */ ){
 
-						dialog.setBody(result);
+						dialog.setBody( result );
 
 					} else {
 
@@ -859,9 +815,9 @@ var Wiki = {
 		});
 		(end)
 	*/
-	jsonrpc: function (method, params, callback) {
+	jsonrpc: function(method, params, callback){
 
-		if (this.JsonUrl) {
+		if( this.JsonUrl ){
 
 			//console.log(method, JSON.stringify(params) );
 
@@ -878,20 +834,20 @@ var Wiki = {
 					'Accept': 'application/json',
 					'X-Request': 'JSON'
 				},
-				onSuccess: function (responseText) {
+				onSuccess: function( responseText ){
 
 					//console.log(responseText, JSON.parse( responseText ), responseText.charCodeAt(8),responseText.codePointAt(8), (encodeURIComponent(responseText)), encodeURIComponent("ä"), encodeURIComponent("Ã")  );
 					callback(responseText == "" ? "" : JSON.parse(responseText));
 					//callback( responseText );
 
 				},
-				onError: function (error) {
+				onError: function(error){
 					//console.log(error);
-					callback(null);
+					callback( null );
 					throw new Error("Wiki rpc error: " + error);
 				}
 
-			}).send("params=" + params);
+			}).send( "params=" + params );
 
 		}
 

--- a/jspwiki-war/src/main/scripts/wiki/Wiki.js
+++ b/jspwiki-war/src/main/scripts/wiki/Wiki.js
@@ -60,763 +60,842 @@ Class: Wiki
 */
 var Wiki = {
 
-    version: "haddock04",  //used to validate compatible preference cookies
-
-    initialize: function(){
-
-        var wiki = this,
-            behavior = new Behavior();
-
-        wiki.add = behavior.add.bind(behavior);
-        wiki.once = behavior.once.bind(behavior);
-        wiki.update = behavior.update.bind(behavior);
-
-
-        // add core jspwiki behaviors; needed to support the default template jsp's
-        wiki.add( "body", wiki.caniuse )
-
-            .add( "[accesskey]", Accesskey )
-
-            //toggle effect:  toggle .active class on this element when clicking toggle element
-            //.add("[data-toggle]", "onToggle", {attr:"data-toggle"})
-            .add( "[data-toggle]", function(element){
-
-                element.onToggle( element.get("data-toggle"), function(isActive){
-                    var pref = element.get("data-toggle-pref");
-                    if (pref) {
-                        wiki.prefs.set(pref, isActive ? "active" : "");
-                    }
-                });
-            })
-
-            //generate modal confirmation boxes, eg prompting to execute
-            //an unrecoverable action such as deleting a page or attachment
-            //.add("[data-modal]", "onModal", {attr:"data-modal"})
-            .add( "[data-modal]", function(element){
-                element.onModal( element.get("data-modal") );
-            })
+	version: "haddock04",  //used to validate compatible preference cookies
+
+	initialize: function () {
+
+		var wiki = this,
+			behavior = new Behavior();
+		wiki.add = behavior.add.bind(behavior);
+		wiki.once = behavior.once.bind(behavior);
+		wiki.update = behavior.update.bind(behavior);
+
+
+		// add core jspwiki behaviors; needed to support the default template jsp's
+		wiki.add("body", wiki.caniuse)
+
+			.add("[accesskey]", Accesskey)
+
+			//toggle effect:  toggle .active class on this element when clicking toggle element
+			//.add("[data-toggle]", "onToggle", {attr:"data-toggle"})
+			.add("[data-toggle]", function (element) {
+
+				element.onToggle(element.get("data-toggle"), function (isActive) {
+					var pref = element.get("data-toggle-pref");
+					if (pref) {
+						wiki.prefs.set(pref, isActive ? "active" : "");
+					}
+				});
+			})
+
+			//generate modal confirmation boxes, eg prompting to execute
+			//an unrecoverable action such as deleting a page or attachment
+			//.add("[data-modal]", "onModal", {attr:"data-modal"})
+			.add("[data-modal]", function (element) {
+				element.onModal(element.get("data-modal"));
+			})
+
+			//hover effects: show/hide this element when hovering over the parent element
+			//.add("[data-toggle]", "onHover", {attr:"data-hover-parent"})
+			.add("[data-hover-parent]", function (element) {
+				element.onHover(element.get("data-hover-parent"));
+			})
+
+			// Click effect: Similar to hover effect, but triggered on click of an element (e.g. for searchbox)
+			// Defined in the following two blocks
+			.add("body", function (element) {
+				// Close open element if clicked anywhere else
+				jq$(element).click(function (event) {
+					var openParent = jq$('.open-click-parent');
+					if (jq$.contains(openParent, event.target)) return;
+					else if (openParent.length > 0 && jq$.contains(openParent[0], event.target)) return;
+					else openParent.removeClass('open open-click-parent');
+				})
+			})
+
+			.add("[data-click-parent]", function (element) {
+				jq$(element).click(function (event) {
+					var parentSelector = jq$(this).attr('data-click-parent');
+					var parent = jq$(parentSelector);
+					var openParent = jq$('.open-click-parent');
+					// Close already open parents
+					if (!openParent.is(parent)) {
+						openParent.removeClass('open open-click-parent');
+					}
+					if (parent.hasClass('open')) {
+						parent.removeClass('open open-click-parent');
+					} else {
+						parent.addClass('open open-click-parent');
+						if (parent.find('input').length > 0) {
+							parent.find("input:first").focus();
+						}
+					}
+					event.preventDefault();
+					event.stopPropagation();
+					return false;
+				});
+			})
+
+			//resize the "data-resize" elements when dragging this element
+			//.add( "[data-resize]", wiki.resizer.bind(wiki) )
+			.add("[data-resize]", function (element) {
+				wiki.resizer(element, $$(element.get("data-resize")));
+			})
+
+			//add header scroll-up/down effect
+			.add(".fixed-header > .header", wiki.yoyo)
+
+			//sticky toolbar in the editor
+			.add(".sticky", function (element) {
+				element.onSticky();
+			})
+
+			//highlight previous search query retreived from a cookie or referrer page
+			.add(".page-content", function (element) {
+
+				var previousQuery = "PrevQuery";
+
+				HighlightQuery(element, wiki.prefs.get(previousQuery));
+				wiki.prefs.erase(previousQuery);
+
+			})
+
+			//activate quick navigation searchbox
+			.add(".searchbox .dropdown-menu", function (element) {
+
+				var recentSearch = "RecentSearch", prefs = wiki.prefs;
+
+				//activate Recent Searches functionality
+				new wiki.Recents(element, {
+					items: prefs.get(recentSearch),
+					onChange: function (items) {
+						items ? prefs.set(recentSearch, items) : prefs.erase(recentSearch);
+					}
+				});
+
+				//activate Quick Navigation functionality
+				new wiki.Findpages(element, {
+					rpc: function (value, callback) {
+						wiki.jsonrpc("/search/pages", [value, 16], callback);
+					},
+					toUrl: wiki.toUrl.bind(wiki),
+					allowClone: function () {
+						return /view|preview|info|attach/.test(wiki.Context);
+					}
+				});
+			})
+
+			//activate ajax search routines on Search.jsp
+			.add("#searchform2", function (form) {
+
+				wiki.search = new wiki.Search(form, {
+					xhrURL: wiki.XHRSearch,
+					onComplete: function () {
+						//console.log(form.query.get("value"));
+						wiki.prefs.set("PrevQuery", form.query.get("value"));
+					}
+				});
+			})
+
+			//activate attachment upload routines
+			.add("#files", Form.File, {
+				max: 8,
+				rpc: function (progressid, callback) {
+					//console.log("progress", progressid);
+					wiki.jsonrpc("/progressTracker", [progressid], callback);
+				}
+			});
+
+		window.addEvents({
+			popstate: wiki.popstate,
+			domready: wiki.domready.bind(wiki)
+		});
+
+	},
 
-            //hover effects: show/hide this element when hovering over the parent element
-            //.add("[data-toggle]", "onHover", {attr:"data-hover-parent"})
-            .add( "[data-hover-parent]", function(element){
-                element.onHover( element.get("data-hover-parent") );
-            })
-
-            //resize the "data-resize" elements when dragging this element
-            //.add( "[data-resize]", wiki.resizer.bind(wiki) )
-            .add( "[data-resize]", function(element){
-                wiki.resizer(element, $$(element.get("data-resize")) );
-            })
+
+	caniuse: function (body) {
+
+		//support for flexbox is broken in IE, do it the hard-way - ugh.
+
+		var isIE11 = !(window.ActiveXObject) && "ActiveXObject" in window;
+		var isIE9or10 = "ActiveXObject" in window;
 
-            //add header scroll-up/down effect
-            .add(".fixed-header > .header", wiki.yoyo)
+		body.ifClass(!(isIE11 || isIE9or10), "can-flex");
+	},
 
-            //sticky toolbar in the editor
-            .add(".sticky", function (element) {
-                element.onSticky();
-            })
+	listenForCloseClick: function (element) {
+		var wiki = this;
+		jq$('body').click(function (event) {
+			var target = $(event.target);
+			if (!element.is(target)) {
+				element.removeClass('open');
+				wiki.stopListeningForCloseClick();
+			}
+		})
+	},
 
-            //highlight previous search query retreived from a cookie or referrer page
-            .add( ".page-content", function(element){
+	stopListeningForCloseClick: function () {
+		jq$('body').unbind('click');
+	},
 
-                var previousQuery = "PrevQuery";
+	/*
+	Function: domready
+		After the DOM is fully loaded:
+		- initialize the meta data wiki properties
+		- initialize the section Links
+		- when the "referrer" url (previous page) contains a "section=" parameter,
+		  scroll the wiki page to the right section
+	*/
+	domready: function () {
 
-                HighlightQuery( element, wiki.prefs.get(previousQuery) );
-                wiki.prefs.erase(previousQuery);
+		var wiki = this;
 
-            })
+		wiki.dropdowns();
 
-            //activate quick navigation searchbox
-            .add( ".searchbox .dropdown-menu", function(element){
+		wiki.meta();
 
-                var recentSearch = "RecentSearch", prefs = wiki.prefs;
+		wiki.prefs = new Hash.Cookie("JSPWikiUserPrefs", {
+			path: wiki.BasePath,
+			duration: 20
+		});
 
-                //activate Recent Searches functionality
-                new wiki.Recents( element, {
-                    items: prefs.get(recentSearch),
-                    onChange: function( items ){
-                        items ? prefs.set(recentSearch, items) : prefs.erase(recentSearch);
-                    }
-                });
+		//Object.each(wiki.prefs.hash, function(item,key){ console.log("PREFS  ",key,"=>",item); });
 
-                //activate Quick Navigation functionality
-                new wiki.Findpages(element, {
-                    rpc: function(value, callback){
-                        wiki.jsonrpc("/search/pages", [value, 16], callback);
-                    },
-                    toUrl: wiki.toUrl.bind(wiki),
-                    allowClone: function(){
-                        return /view|preview|info|attach/.test( wiki.Context );
-                    }
-                });
-            })
+		if (wiki.version != wiki.prefs.get("version")) {
+			wiki.prefs.empty();
+			wiki.prefs.set("version", wiki.version);
+		}
 
-            //activate ajax search routines on Search.jsp
-            .add( "#searchform2", function(form){
+		//The initial Sidebar will be active depending on a cookie state.
+		//However, for small screen,  the default state will be hidden.
+		wiki.media("(min-width:768px)", function (screenIsLarge) {
 
-                wiki.search = new wiki.Search( form, {
-                    xhrURL: wiki.XHRSearch,
-                    onComplete: function(){
-                        //console.log(form.query.get("value"));
-                        wiki.prefs.set("PrevQuery", form.query.get("value"));
-                    }
-                });
-            })
+			if (!screenIsLarge) {
+				$$(".content")[0].removeClass("active"); //always hide sidebar on pageload for narrow screens
+			}
 
-            //activate attachment upload routines
-            .add( "#files", Form.File, {
-                max: 8,
-                rpc: function(progressid, callback){
-                    //console.log("progress", progressid);
-                    wiki.jsonrpc("/progressTracker", [progressid], callback);
-                }
-            });
+		});
 
-        window.addEvents({
-            popstate: wiki.popstate,
-            domready: wiki.domready.bind(wiki)
-        });
+		//wiki.url = null;  //CHECK:  why this is needed?
+		//console.log( wiki.prefs.get("SectionEditing") , wiki.EditPermission ,wiki.Context );
+		if (wiki.prefs.get("SectionEditing") && wiki.EditPermission && (wiki.Context != "preview")) {
 
-    },
+			wiki.addEditLinks(wiki.toUrl(wiki.PageName, true));
 
+		}
 
-    caniuse: function( body ){
+		//console.log( "section", document.referrer, document.referrer.match( /\&section=(\d+)$/ ) );
+		wiki.scrollTo((document.referrer.match(/\&section=(\d+)$/) || [, -1])[1]);
 
-        //support for flexbox is broken in IE, do it the hard-way - ugh.
+		// initialize all registered behaviors
+		wiki.update();
 
-        var isIE11 = !(window.ActiveXObject) && "ActiveXObject" in window;
-        var isIE9or10 = "ActiveXObject" in window;
+		//on page-load, also read the #hash and fire popstate events
+		wiki.popstate();
 
-        body.ifClass( !( isIE11 || isIE9or10 ) , "can-flex");
+		wiki.autofocus();
 
-    },
+	},
 
 
-    /*
-    Function: domready
-        After the DOM is fully loaded:
-        - initialize the meta data wiki properties
-        - initialize the section Links
-        - when the "referrer" url (previous page) contains a "section=" parameter,
-          scroll the wiki page to the right section
-    */
-    domready: function(){
+	/*
+	Function: media query event handler
+		Catch media-query changes  (eg screen width,  portrait/landscape changes,  etc...
+	*/
+	media: function (query, callback) {
 
-        var wiki = this;
+		function queryChanged(event) {
+			callback(event.matches);
+		}
 
-        wiki.dropdowns();
+		if (/*window.*/ matchMedia) {
 
-        wiki.meta();
+			var mediaQueryList = matchMedia(query);
+			mediaQueryList.addListener(queryChanged);
+			queryChanged(mediaQueryList);
+		}
 
-        wiki.prefs = new Hash.Cookie("JSPWikiUserPrefs", {
-            path: wiki.BasePath,
-            duration: 20
-        });
+	},
 
-        //Object.each(wiki.prefs.hash, function(item,key){ console.log("PREFS  ",key,"=>",item); });
+	/*
+	Function: yoyo ( header )
+		Add a yoyo effect to the header:  hide it on scroll down, show it again on scroll up.
 
-        if( wiki.version != wiki.prefs.get("version") ){
-            wiki.prefs.empty();
-            wiki.prefs.set("version", wiki.version);
-        }
+	Inspired by: https://github.com/WickyNilliams/headroom.js
 
-        //The initial Sidebar will be active depending on a cookie state.
-        //However, for small screen,  the default state will be hidden.
-        wiki.media("(min-width:768px)", function( screenIsLarge ){
+	DOM Structure:
+	(start code)
+		div[style='padding-top:nn']    => nn==height of header;  push content down
+		div.header.yoyo[.scrolling-down]  => css: position=fixed
+	(end)
 
-            if(!screenIsLarge){
-                $$(".content")[0].removeClass("active"); //always hide sidebar on pageload for narrow screens
-            }
+	*/
+	yoyo: function (header) {
 
-        });
+		var height = "offsetHeight",
+			scrollY,
+			lastScrollY = 0,
 
-        //wiki.url = null;  //CHECK:  why this is needed?
-        //console.log( wiki.prefs.get("SectionEditing") , wiki.EditPermission ,wiki.Context );
-        if( wiki.prefs.get("SectionEditing") && wiki.EditPermission && (wiki.Context != "preview") ){
+			//add spacer just infront of fixed element,
+			//and adjust height == header (fixed elements do not take space in the dom)
+			spacer = "div".slick().inject(header, "before"),
+			busy;
 
-            wiki.addEditLinks( wiki.toUrl( wiki.PageName, true ) );
+		function update() {
 
-        }
+			scrollY = window.getScroll().y;
 
-        //console.log( "section", document.referrer, document.referrer.match( /\&section=(\d+)$/ ) );
-        wiki.scrollTo( ( document.referrer.match( /\&section=(\d+)$/ ) || [,-1])[1] );
+			spacer.style.paddingTop = header[height] + "px"; //update after window resize
 
-        // initialize all registered behaviors
-        wiki.update();
+			// Limit scroll top to counteract iOS / OSX bounce.
+			scrollY = scrollY.limit(0, window.getScrollSize().y - window.getSize().y);
 
-        //on page-load, also read the #hash and fire popstate events
-        wiki.popstate();
+			if (Math.abs(lastScrollY - scrollY) > 5 /* minimum difference */) {
 
-        wiki.autofocus();
+				header.ifClass(scrollY > lastScrollY && scrollY > header[height], "scrolling-down");
+				lastScrollY = scrollY;
 
-    },
+			}
+			busy = false;
+		}
 
+		function handleEvent() {
+			if (!busy) {
+				busy = true;
+				requestAnimationFrame(update);
+			}
+		}
 
-    /*
-    Function: media query event handler
-        Catch media-query changes  (eg screen width,  portrait/landscape changes,  etc...
-    */
-    media: function(query, callback){
+		window.addEvents({scroll: handleEvent, resize: handleEvent});
+		update(); //first run: set height of the spacer
 
-        function queryChanged( event ){ callback( event.matches ); }
+	},
 
-        if( /*window.*/ matchMedia ){
 
-            var mediaQueryList = matchMedia( query );
-            mediaQueryList.addListener( queryChanged );
-            queryChanged( mediaQueryList );
-        }
+	/*
+	Function: popstate
+		When pressing the back-button, the "popstate" event is fired.
+		This popstate function will fire a internal 'popstate' event
+		on the target DOM element.
 
-    },
+		Behaviors (such as Tabs or Accordions) can push the ID of their
+		visible content on the window.location hash.
+		This ID can be retrieved when the back-button is pressed.
 
-    /*
-    Function: yoyo ( header )
-        Add a yoyo effect to the header:  hide it on scroll down, show it again on scroll up.
+		When clicking a link referring to hidden content (tab, accordion), the
+		popstate event is 'bubbled' up the DOM tree.
 
-    Inspired by: https://github.com/WickyNilliams/headroom.js
+	*/
+	popstate: function () {
 
-    DOM Structure:
-    (start code)
-        div[style='padding-top:nn']    => nn==height of header;  push content down
-        div.header.yoyo[.scrolling-down]  => css: position=fixed
-    (end)
+		var target = $(location.hash.slice(1)),
+			events,
+			popstate = "popstate";
 
-    */
-    yoyo: function( header ){
+		//console.log( popstate, location.hash, target );
 
-        var height = "offsetHeight",
-            scrollY,
-            lastScrollY = 0,
+		//only send popstate events to targets within the main page; eg not sidebar
+		if (target && target.getParent(".page-content")) {
 
-            //add spacer just infront of fixed element,
-            //and adjust height == header (fixed elements do not take space in the dom)
-            spacer = "div".slick().inject(header, "before"),
-            busy;
+			while (!target.hasClass("page-content")) {
 
-        function update(){
+				events = target.retrieve("events"); //mootools specific - to read registered events on elements
 
-            scrollY = window.getScroll().y;
+				if (events && events[popstate]) {
 
-            spacer.style.paddingTop = header[height]+"px"; //update after window resize
+					target.fireEvent(popstate);
 
-            // Limit scroll top to counteract iOS / OSX bounce.
-            scrollY = scrollY.limit(0, window.getScrollSize().y - window.getSize().y);
+				}
 
-            if (Math.abs(lastScrollY - scrollY) > 5 /* minimum difference */) {
+				target = target.getParent();
 
-                header.ifClass(scrollY > lastScrollY && scrollY > header[height], "scrolling-down");
-                lastScrollY = scrollY;
+			}
+		}
+	},
 
-            }
-            busy = false;
-        }
+	autofocus: function () {
 
-        function handleEvent(){
-            if(!busy){
-              busy = true;
-              requestAnimationFrame( update );
-            }
-        }
+		var els, element;
 
-        window.addEvents({ scroll: handleEvent, resize: handleEvent });
-        update(); //first run: set height of the spacer
+		if (!("autofocus" in document.createElement("input"))) {
+			// editor/plain.jsp  textarea#wikiText
+			// login.jsp         input#j_username
+			// prefs/prefs       input#assertedName
+			// find              input#query2
+			els = $$("input[autofocus=autofocus], textarea[autofocus=autofocus]");
+			while (els[0]) {
+				element = els.shift();
+				//console.log("autofocus", element, element.autofocus, element.isVisible(), element.offsetWidth, element.offsetHeight, "$", element.getStyle("display"), "$");
+				if (element.isVisible()) {
+					element.focus();
+					return;
+				}
+			}
+		}
 
-    },
+	},
 
+	/*
+	Function: meta
+		Read all the "meta" dom elements, prefixed with "wiki",
+		and add them as properties to the wiki object.
+		EG  <meta name="wikiContext">  becomes  wiki.Context
+		* wikiContext : jspwiki requestcontext variable (view, edit, info, ...)
+		* wikiBaseUrl
+		* wikiPageUrl: page url template with dummy pagename "%23%24%25"
+		* wikiEditUrl : edit page url
+		* wikiJsonUrl : JSON-RPC / AJAX url
+		* wikiPageName : pagename without blanks
+		* wikiUserName
+		* wikiTemplateUrl : path of the jsp template
+		* wikiApplicationName
+		* wikiEditPermission
+	*/
+	meta: function () {
 
-    /*
-    Function: popstate
-        When pressing the back-button, the "popstate" event is fired.
-        This popstate function will fire a internal 'popstate' event
-        on the target DOM element.
+		var url,
+			wiki = this,
+			host = location.host;
 
-        Behaviors (such as Tabs or Accordions) can push the ID of their
-        visible content on the window.location hash.
-        This ID can be retrieved when the back-button is pressed.
+		$$("meta[name^=wiki]").each(function (el) {
+			wiki[el.get("name").slice(4)] = el.get("content") || "";
+		});
 
-        When clicking a link referring to hidden content (tab, accordion), the
-        popstate event is 'bubbled' up the DOM tree.
+		// BasePath: if JSPWiki is installed in the root, then we have to make sure that
+		// the cookie-cutter works properly here.
+		url = wiki.BaseUrl;
+		url = url ? url.slice(url.indexOf(host) + host.length, -1) : "";
+		wiki.BasePath = (url /*===""*/) ? url : "/";
+		//console.log(url, host, wiki.BaseUrl + " basepath: " + wiki.BasePath);
 
-    */
-    popstate: function(){
+	},
 
-        var target = $(location.hash.slice(1)),
-            events,
-            popstate = "popstate";
+	/*
+	Function: dropdowns
+		Parse special wikipages such ase MoreMenu, HomeMenu
+		and format them as bootstrap compatible dropdown menus.
+	*/
+	dropdowns: function () {
 
-        //console.log( popstate, location.hash, target );
+		$$("ul.dropdown-menu > li > ul").each(function (ul) {
 
-        //only send popstate events to targets within the main page; eg not sidebar
-        if( target && target.getParent(".page-content") ){
+			var li, parentLi = ul.getParent();
 
-            while( !target.hasClass("page-content") ){
+			while ((li = ul.getFirst("li"))) {
 
-                events = target.retrieve("events"); //mootools specific - to read registered events on elements
+				if (li.innerHTML.trim() == "----") {
 
-                if( events && events[popstate] ){
+					li.addClass("divider");
 
-                    target.fireEvent(popstate);
+				} else if (!li.getFirst() || !li.getFirst("a")) {
 
-                }
+					li.addClass("dropdown-header");
 
-                target = target.getParent();
+				}
+				li.inject(parentLi, "before");
 
-            }
-        }
-    },
+			}
+			ul.dispose();
 
-    autofocus: function(){
+		});
 
-        var els, element;
+		/* (deprecated) "pre-HADDOCK" moremenu style
+			  Consists of a list of links, with \\ delimitters
+			  Each <p> becomes a set of <li>, one for each link
+			  The block is terminated with a divider, if more <p>'s are coming
+		*/
+		$$("ul.dropdown-menu > li.more-menu > p").each(function (element) {
 
-        if( !("autofocus" in document.createElement("input") ) ){
-            // editor/plain.jsp  textarea#wikiText
-            // login.jsp         input#j_username
-            // prefs/prefs       input#assertedName
-            // find              input#query2
-            els = $$("input[autofocus=autofocus], textarea[autofocus=autofocus]");
-            while( els[0] ){
-                element = els.shift();
-                //console.log("autofocus", element, element.autofocus, element.isVisible(), element.offsetWidth, element.offsetHeight, "$", element.getStyle("display"), "$");
-                if( element.isVisible() ){
-                    element.focus();
-                    return;
-                }
-            }
-        }
+			var parentLi = element.getParent();
 
-    },
+			element.getElements('a').each(function (link) {
+				["li", [link]].slick().inject(parentLi, "before");
+			});
+			if (element.getNext("p *,hr")) {
+				"li.divider".slick().inject(parentLi, "before");
+			}
+			element.dispose();
 
-    /*
-    Function: meta
-        Read all the "meta" dom elements, prefixed with "wiki",
-        and add them as properties to the wiki object.
-        EG  <meta name="wikiContext">  becomes  wiki.Context
-        * wikiContext : jspwiki requestcontext variable (view, edit, info, ...)
-        * wikiBaseUrl
-        * wikiPageUrl: page url template with dummy pagename "%23%24%25"
-        * wikiEditUrl : edit page url
-        * wikiJsonUrl : JSON-RPC / AJAX url
-        * wikiPageName : pagename without blanks
-        * wikiUserName
-        * wikiTemplateUrl : path of the jsp template
-        * wikiApplicationName
-        * wikiEditPermission
-    */
-    meta: function(){
+		});
 
-        var url,
-            wiki = this,
-            host = location.host;
+	},
 
-        $$("meta[name^=wiki]").each( function(el){
-            wiki[el.get("name").slice(4)] = el.get("content") || "";
-        });
+	/*
+	Function: getSections
+		Returns the list of all section headers, excluding the header of the Table Of Contents.
+	*/
+	getSections: function () {
 
-        // BasePath: if JSPWiki is installed in the root, then we have to make sure that
-        // the cookie-cutter works properly here.
-        url = wiki.BaseUrl;
-        url = url ? url.slice(url.indexOf(host) + host.length, -1) : "";
-        wiki.BasePath = (url /*===""*/) ? url : "/";
-        //console.log(url, host, wiki.BaseUrl + " basepath: " + wiki.BasePath);
+		return $$(".page-content [id^=section]:not(#section-TOC)");
 
-    },
+	},
 
-    /*
-    Function: dropdowns
-        Parse special wikipages such ase MoreMenu, HomeMenu
-        and format them as bootstrap compatible dropdown menus.
-    */
-    dropdowns: function(){
+	/*
+	Function: scrollTo
+		Scrolls the page to the section previously being edited - if any
+		Section counting starts at 1??
+	*/
+	scrollTo: function (index) {
 
-        $$( "ul.dropdown-menu > li > ul" ).each( function(ul){
+		//console.log("Scroll to section ", index, ", Number of sections:", this.getSections().length );
+		var element = this.getSections()[index];
 
-            var li, parentLi = ul.getParent();
+		if (element) {
+			location.replace("#" + element.get("id"));
+		}
 
-            while( (li = ul.getFirst("li")) ){
+	},
 
-                if( li.innerHTML.trim() == "----" ){
+	/*
+	Property: toUrl
+		Convert a wiki pagename to a full wiki-url.
+		Use the correct url template: view(default), edit-url or clone-url
+	*/
+	toUrl: function (pagename, isEdit, isClone) {
 
-                    li.addClass("divider");
+		var urlTemplate = isClone ? this.CloneUrl : isEdit ? this.EditUrl : this.PageUrl;
+		return urlTemplate.replace(/%23%24%25/, this.cleanPageName(pagename));
 
-                } else if( !li.getFirst() || !li.getFirst("a") ){
+	},
 
-                    li.addClass("dropdown-header");
+	/*
+	Property: toPageName
+		Parse a wiki-url and return the corresponding wiki pagename
+	*/
+	toPageName: function (url) {
 
-                }
-                li.inject(parentLi, "before");
+		var s = this.PageUrl.escapeRegExp().replace(/%23%24%25/, "(.+)");
+		return (url.match(RegExp(s)) || [0, false])[1];
 
-            }
-            ul.dispose();
+	},
 
-        });
+	/*
+	Property: cleanPageName
+		Remove all not-allowed chars from a pagename.
+		Trim all whitespace, allow letters, digits and punctuation chars: ()&+, -=._$
+		Mirror of org.apache.wiki.parser.MarkupParser.cleanPageName()
+	*/
+	cleanPageName: function (pagename) {
 
-        /* (deprecated) "pre-HADDOCK" moremenu style
-              Consists of a list of links, with \\ delimitters
-              Each <p> becomes a set of <li>, one for each link
-              The block is terminated with a divider, if more <p>'s are coming
-        */
-        $$( "ul.dropdown-menu > li.more-menu > p" ).each( function(element){
+		//\w is short for [A-Z_a-z0-9_]
+		return pagename.clean().replace(/[^\w\u00C0-\u1FFF\u2800-\uFFFD\(\)&\+,\-=\.\$ ]/g, "");
 
-            var parentLi = element.getParent();
+	},
 
-            element.getElements('a').each( function(link){
-                ["li",[link]].slick().inject(parentLi, "before");
-            });
-            if( element.getNext("p *,hr") ){
-                "li.divider".slick().inject(parentLi, "before") ;
-            }
-            element.dispose();
+	/*
+	Function: addEditLinks
+		Add to each Section title (h2/h3/h4) a quick edit link.
+		FFS: should better move server side
+		FFS: add section #hash to automatically go back to the section being edited
+	*/
+	addEditLinks: function (url) {
 
-        });
+		var description = "quick.edit".localize();
 
-    },
+		url = url + (url.contains("?") ? "&" : "?") + "section=";
 
-    /*
-    Function: getSections
-        Returns the list of all section headers, excluding the header of the Table Of Contents.
-    */
-    getSections: function(){
+		this.getSections().each(function (element, index) {
 
-        return $$(".page-content [id^=section]:not(#section-TOC)");
+			element.grab("a.editsection".slick({html: description, href: url + index}));
 
-    },
+		});
 
-    /*
-    Function: scrollTo
-        Scrolls the page to the section previously being edited - if any
-        Section counting starts at 1??
-    */
-    scrollTo: function( index ){
+	},
 
-        //console.log("Scroll to section ", index, ", Number of sections:", this.getSections().length );
-        var element = this.getSections()[index];
+	/*
+	Function: configPrefs  (sofar only used in edit mode)
+		Initialize the configuration checkboxes from the wiki prefs cookie.
+		Save any change to the checkboxes back into the wiki prefs cookie.
+		Also take care of switching between different editor types, saving the
+		new editor type into the wiki prefs cookie.
 
-        if( element ){
-            location.replace( "#" + element.get("id") );
-        }
+		EG: tabcompletion, smartpairs, autosuggest, livepreview, previewcolumn. editor-type
+	*/
+	configPrefs: function (form, onChangeFn) {
 
-    },
+		var wiki = this;
 
-    /*
-    Property: toUrl
-        Convert a wiki pagename to a full wiki-url.
-        Use the correct url template: view(default), edit-url or clone-url
-    */
-    toUrl: function(pagename, isEdit, isClone){
+		function onCheck() {
 
-        var urlTemplate = isClone ? this.CloneUrl : isEdit ? this.EditUrl : this.PageUrl;
-        return urlTemplate.replace(/%23%24%25/, this.cleanPageName(pagename) );
+			var cmd = this.getAttribute("data-cmd"),
+				isChecked = this.checked;
 
-    },
+			wiki.toggleLivePreview(form, cmd, isChecked);
+			wiki.prefs.set(cmd, isChecked);  //persist in the pref cookie
+			if (onChangeFn) {
+				onChangeFn(cmd, isChecked);
+			}
 
-    /*
-    Property: toPageName
-        Parse a wiki-url and return the corresponding wiki pagename
-    */
-    toPageName: function(url){
+		}
 
-        var s = this.PageUrl.escapeRegExp().replace(/%23%24%25/, "(.+)");
-        return ( url.match( RegExp(s) ) || [0, false] )[1];
+		//Handle all configuration checkboxes
+		form.getElements("[type=checkbox][data-cmd]").each(function (el) {
 
-    },
+			el.checked = !!wiki.prefs.get(el.getAttribute("data-cmd"));
+			el.addEvent("click", onCheck);
+			onCheck.apply(el);
 
-    /*
-    Property: cleanPageName
-        Remove all not-allowed chars from a pagename.
-        Trim all whitespace, allow letters, digits and punctuation chars: ()&+, -=._$
-        Mirror of org.apache.wiki.parser.MarkupParser.cleanPageName()
-    */
-    cleanPageName: function( pagename ){
+		});
 
-        //\w is short for [A-Z_a-z0-9_]
-        return pagename.clean().replace(/[^\w\u00C0-\u1FFF\u2800-\uFFFD\(\)&\+,\-=\.\$ ]/g, "");
+		//Persist the selected editor type in the pref cookie
+		form.getElements("a.editor-type").addEvent("click", function () {
 
-    },
+			wiki.prefs.set("editor", this.get("text"));
 
-    /*
-    Function: addEditLinks
-        Add to each Section title (h2/h3/h4) a quick edit link.
-        FFS: should better move server side
-        FFS: add section #hash to automatically go back to the section being edited
-    */
-    addEditLinks: function( url ){
+		});
 
-        var description = "quick.edit".localize();
+	},
 
-        url = url + (url.contains("?") ? "&" : "?") + "section=";
 
-        this.getSections().each( function(element, index){
+	toggleLivePreview: function (container, cmd, state) {
 
-            element.grab("a.editsection".slick({ html: description, href: url + index }));
+		if (cmd.test(/livepreview|previewcolumn/)) {
 
-        });
+			var previewcontainer = container.getElement(".edit-area").ifClass(state, cmd),
+				ajaxpreview = container.getElement(".ajaxpreview");
 
-    },
+			if (cmd == "livepreview") {
 
-    /*
-    Function: configPrefs  (sofar only used in edit mode)
-        Initialize the configuration checkboxes from the wiki prefs cookie.
-        Save any change to the checkboxes back into the wiki prefs cookie.
-        Also take care of switching between different editor types, saving the
-        new editor type into the wiki prefs cookie.
+				//disable the previewcolumn toolbar cmd checkbox
+				container.getElement("[data-cmd=previewcolumn]").disabled = !state;
 
-        EG: tabcompletion, smartpairs, autosuggest, livepreview, previewcolumn. editor-type
-    */
-    configPrefs: function( form, onChangeFn ){
+			} else {
 
-        var wiki = this;
+				/* Toggle the position of the preview-area in the dom
 
-        function onCheck(){
+				1. HORIZONTAL SIDE BY SIDE VIEW
+				div.snip
+					div.toolbar
+					div.edit-area.livepreview.previewcolumn
+						div.col-50
+						div.col-50.ajaxpreview
+					div.resizer
 
-            var cmd = this.getAttribute("data-cmd"),
-                isChecked = this.checked;
+				2. VERTICAL VIEW
+				div.snip
+					div.toolbar
+					div.edit-area.livepreview
+						div.col-50
+					div.resizer
+					div.col-50.ajaxpreview
+				*/
 
-            wiki.toggleLivePreview(form, cmd, isChecked);
-            wiki.prefs.set(cmd, isChecked);  //persist in the pref cookie
-            if( onChangeFn ){ onChangeFn(cmd, isChecked); }
+				if (!state) {
+					previewcontainer = previewcontainer.getParent();
+				}
+				previewcontainer.grab(ajaxpreview);
 
-        }
+			}
 
-        //Handle all configuration checkboxes
-        form.getElements("[type=checkbox][data-cmd]").each( function( el ){
 
-            el.checked = !!wiki.prefs.get(el.getAttribute("data-cmd"));
-            el.addEvent("click", onCheck );
-            onCheck.apply(el);
+			// Auto size editor and live preview window
+			var editPanes = jq$('.editor');
+			for (var i = 0; i < editPanes.length; i++) {
+				var editor = jq$(editPanes[i]);
+				if (editor.is('#editorarea')) continue;
+				editor.autosize();
+				editor.trigger('autosize.resize');
+			}
 
-        });
+			jq$(ajaxpreview).height(jq$(editPanes[0]).height());
+		}
 
-        //Persist the selected editor type in the pref cookie
-        form.getElements("a.editor-type").addEvent("click", function(){
 
-            wiki.prefs.set("editor", this.get("text"));
+	},
 
-        });
+	getXHRPreview: function (getContent, previewElement) {
 
-    },
+		var wiki = this,
+			loading = "loading",
+			preview = function (p) {
+				previewElement.removeClass(loading).set("text", p);
+			};
 
+		return (function () {
 
-    toggleLivePreview: function( container, cmd, state ){
+			previewElement.addClass(loading);
 
-        if( cmd.test( /livepreview|previewcolumn/ ) ){
+			new Request({
+				url: wiki.XHRHtml2Markup,
+				data: {
+					htmlPageText: getContent()
+				},
+				onSuccess: function (responseText) {
+					preview(responseText.trim());
+				},
+				onFailure: function (e) {
+					preview("Sorry, HTML to Wiki Markup conversion failed :=() " + e);
+				}
+			}).send();
 
-            var previewcontainer = container.getElement(".edit-area").ifClass(state, cmd),
-                ajaxpreview = container.getElement(".ajaxpreview");
+		}).debounce();
 
-            if( cmd == "livepreview" ){
+	},
 
-                //disable the previewcolumn toolbar cmd checkbox
-                container.getElement("[data-cmd=previewcolumn]").disabled = !state;
+	/*
+	Behavior: resizer
+		Resize the target element, by dragging a .resizer handle.
+		Multiple elements can be resized via the callback.
+		The .resizer element can specify a prefs cookie to retrieve/store the height.
+		Used by the plain and wysiwyg editor.
 
-            } else {
+	Arguments:
+		target - DOM element to be resized
+		callback - function, to allow resizing of more elements
 
-                /* Toggle the position of the preview-area in the dom
+	Globals:
+		wiki - main wiki object, to get/set preference fields
+		textarea - resizable textarea (DOM element)
+		preview - preview (DOM element)
+	*/
+	/*
+	wiki.add(".resizer",function(element){...}
 
-                1. HORIZONTAL SIDE BY SIDE VIEW
-                div.snip
-                    div.toolbar
-                    div.edit-area.livepreview.previewcolumn
-                        div.col-50
-                        div.col-50.ajaxpreview
-                    div.resizer
 
-                2. VERTICAL VIEW
-                div.snip
-                    div.toolbar
-                    div.edit-area.livepreview
-                        div.col-50
-                    div.resizer
-                    div.col-50.ajaxpreview
-                */
+	[data-resize] : resize target,  can be multiple elements
 
-                if( !state ){ previewcontainer = previewcontainer.getParent(); }
-                previewcontainer.grab(ajaxpreview);
+	div.resizer[data-resize=".pagecontent"] => for add-comment sections
+	div.resizer[data-resize=".ajaxpreview,.snipeable"][data-pref=editorHeight]
+	*/
+	resizer: function (handle, targets, dragCallback) {
 
-            }
-        }
-    },
+		var pref = handle.get("data-pref"),
+			prefs = this.prefs,
+			target;
 
-    getXHRPreview: function( getContent, previewElement ){
+		function showDragState(add) {
+			handle.ifClass(add, "dragging");
+		}
 
-        var wiki = this,
-            loading = "loading",
-            preview = function(p){ previewElement.removeClass(loading).set("text", p);};
+		if (!targets[0]) {
+			return;
+		}
 
-        return (function(){
+		//set the initial size of the targets
+		if (pref) {
+			targets.setStyle("height", prefs.get(pref) || 300);
+		}
 
-            previewElement.addClass(loading);
+		target = targets.pop();
 
-            new Request({
-                url: wiki.XHRHtml2Markup,
-                data: {
-                    htmlPageText: getContent()
-                },
-                onSuccess: function(responseText){
-                    preview( responseText.trim() );
-                },
-                onFailure: function(e){
-                    preview( "Sorry, HTML to Wiki Markup conversion failed :=() " + e );
-                }
-            }).send();
+		target.makeResizable({
+			handle: handle,
+			modifiers: {x: null},
+			onDrag: function () {
+				var h = this.value.now.y;
+				if (pref) {
+					prefs.set(pref, h);
+				}
+				if (targets) {
+					targets.setStyle("height", h);
+				}
+				if (dragCallback) {
+					dragCallback(h);
+				}
+			},
+			onBeforeStart: showDragState.pass(true),
+			onComplete: showDragState.pass(false),
+			onCancel: showDragState.pass(false)
+		});
 
-        }).debounce();
+	},
 
-    },
 
-    /*
-    Behavior: resizer
-        Resize the target element, by dragging a .resizer handle.
-        Multiple elements can be resized via the callback.
-        The .resizer element can specify a prefs cookie to retrieve/store the height.
-        Used by the plain and wysiwyg editor.
+	pageDialog: function (caption, method) {
 
-    Arguments:
-        target - DOM element to be resized
-        callback - function, to allow resizing of more elements
+		var wiki = this;
 
-    Globals:
-        wiki - main wiki object, to get/set preference fields
-        textarea - resizable textarea (DOM element)
-        preview - preview (DOM element)
-    */
-    /*
-    wiki.add(".resizer",function(element){...}
+		return [Dialog.Selection, {
 
+			caption: caption,
 
-    [data-resize] : resize target,  can be multiple elements
+			onOpen: function (dialog) {
 
-    div.resizer[data-resize=".pagecontent"] => for add-comment sections
-    div.resizer[data-resize=".ajaxpreview,.snipeable"][data-pref=editorHeight]
-    */
-    resizer: function( handle, targets, dragCallback ){
+				var key = dialog.getValue();
 
-        var pref = handle.get("data-pref"),
-            prefs = this.prefs,
-            target;
+				//if empty link, than fetch list of attachments of the open page
+				if (!key || (key.trim() == '')) {
 
-        function showDragState(add){ handle.ifClass(add, "dragging"); }
+					key = wiki.PageName + "/";
 
-        if( !targets[0] ){ return; }
+				}
 
-        //set the initial size of the targets
-        if( pref ){
-            targets.setStyle("height", prefs.get(pref) || 300 );
-        }
+				wiki.jsonrpc(method, [key, 30], function (result) {
 
-        target = targets.pop();
+					//console.log("jsonrpc result", result, !!result[0] );
+					if (result[0] /* length > 0 */) {
 
-        target.makeResizable({
-            handle: handle,
-            modifiers: { x: null },
-            onDrag: function(){
-                var h = this.value.now.y;
-                if( pref ){ prefs.set(pref, h); }
-                if( targets ){ targets.setStyle("height", h); }
-                if( dragCallback ){ dragCallback(h); }
-            },
-            onBeforeStart: showDragState.pass(true),
-            onComplete: showDragState.pass(false),
-            onCancel: showDragState.pass(false)
-        });
+						dialog.setBody(result);
 
-    },
+					} else {
 
+						dialog.hide();
 
-    pageDialog: function( caption, method ){
+					}
+				});
+			}
+		}];
 
-        var wiki = this;
+	},
 
-        return [ Dialog.Selection, {
+	/*
+	Function: jsonrpc
+		Generic json-rpc routines to talk to the backend jspwiki-engine.
+	Note:
+		Uses the JsonUrl which is read from the meta element "WikiJsonUrl"
+		{{{ <meta name="wikiJsonUrl" content="/JSPWiki-pipo/JSON-RPC" /> }}}
 
-            caption: caption,
+	Supported rpc calls:
+		- {{search.findPages}} gets the list of pagenames with partial match
+		- {{progressTracker.getProgress}} get a progress indicator of attachment upload
+		- {{search.getSuggestions}} gets the list of pagenames with partial match
 
-            onOpen: function( dialog ){
+	Example:
+		(start code)
+		//Wiki.ajaxJsonCall('/search/pages,[Janne,20]', function(result){
+		Wiki.jsonrpc("search.findPages", ["Janne", 20], function(result){
+			//do something with the resulting json object
+		});
+		(end)
+	*/
+	jsonrpc: function (method, params, callback) {
 
-                var key = dialog.getValue();
+		if (this.JsonUrl) {
 
-                //if empty link, than fetch list of attachments of the open page
-                if( !key || (key.trim()=='') ){
+			//console.log(method, JSON.stringify(params) );
 
-                    key = wiki.PageName + "/";
+			//NOTE:  this is half a JSON rpc ... only responseText is JSON formatted
+			new Request({
+				url: this.JsonUrl + method,
+				//method:"post"     //defaults to "POST"
+				//urlEncoded: true, //content-type header = www-form-urlencoded + encoding
+				//encoding: "utf-8",
+				//encoding: "ISO-8859-1",
+				headers: {
+					//'X-Requested-With': 'XMLHttpRequest',
+					//'Accept': 'text/javascript, text/html, application/xml, text/xml, */*'
+					'Accept': 'application/json',
+					'X-Request': 'JSON'
+				},
+				onSuccess: function (responseText) {
 
-                }
+					//console.log(responseText, JSON.parse( responseText ), responseText.charCodeAt(8),responseText.codePointAt(8), (encodeURIComponent(responseText)), encodeURIComponent("ä"), encodeURIComponent("Ã")  );
+					callback(responseText == "" ? "" : JSON.parse(responseText));
+					//callback( responseText );
 
-                wiki.jsonrpc( method, [key, 30], function( result ){
+				},
+				onError: function (error) {
+					//console.log(error);
+					callback(null);
+					throw new Error("Wiki rpc error: " + error);
+				}
 
-                    //console.log("jsonrpc result", result, !!result[0] );
-                    if( result[0] /* length > 0 */ ){
+			}).send("params=" + params);
 
-                        dialog.setBody( result );
+		}
 
-                    } else {
-
-                        dialog.hide();
-
-                    }
-                });
-            }
-        }];
-
-    },
-
-    /*
-    Function: jsonrpc
-        Generic json-rpc routines to talk to the backend jspwiki-engine.
-    Note:
-        Uses the JsonUrl which is read from the meta element "WikiJsonUrl"
-        {{{ <meta name="wikiJsonUrl" content="/JSPWiki-pipo/JSON-RPC" /> }}}
-
-    Supported rpc calls:
-        - {{search.findPages}} gets the list of pagenames with partial match
-        - {{progressTracker.getProgress}} get a progress indicator of attachment upload
-        - {{search.getSuggestions}} gets the list of pagenames with partial match
-
-    Example:
-        (start code)
-        //Wiki.ajaxJsonCall('/search/pages,[Janne,20]', function(result){
-        Wiki.jsonrpc("search.findPages", ["Janne", 20], function(result){
-            //do something with the resulting json object
-        });
-        (end)
-    */
-    jsonrpc: function(method, params, callback){
-
-        if( this.JsonUrl ){
-
-            //console.log(method, JSON.stringify(params) );
-
-            //NOTE:  this is half a JSON rpc ... only responseText is JSON formatted
-            new Request({
-                url: this.JsonUrl + method,
-                //method:"post"     //defaults to "POST"
-                //urlEncoded: true, //content-type header = www-form-urlencoded + encoding
-                //encoding: "utf-8",
-                //encoding: "ISO-8859-1",
-        		headers: {
-		        	//'X-Requested-With': 'XMLHttpRequest',
-			        //'Accept': 'text/javascript, text/html, application/xml, text/xml, */*'
-        			'Accept': 'application/json',
-		        	'X-Request': 'JSON'
-		        },
-                onSuccess: function( responseText ){
-
-                    //console.log(responseText, JSON.parse( responseText ), responseText.charCodeAt(8),responseText.codePointAt(8), (encodeURIComponent(responseText)), encodeURIComponent("ä"), encodeURIComponent("Ã")  );
-                    callback(responseText == "" ? "" : JSON.parse(responseText));
-                    //callback( responseText );
-
-                },
-                onError: function(error){
-                    //console.log(error);
-                    callback( null );
-                    throw new Error("Wiki rpc error: " + error);
-                }
-
-            }).send( "params=" + params );
-
-        }
-
-    }
+	}
 
 };
 

--- a/jspwiki-war/src/main/scripts/wiki/Wiki.js
+++ b/jspwiki-war/src/main/scripts/wiki/Wiki.js
@@ -60,798 +60,798 @@ Class: Wiki
 */
 var Wiki = {
 
-	version: "haddock04",  //used to validate compatible preference cookies
-
-	initialize: function(){
-
-		var wiki = this,
-			behavior = new Behavior();
-
-		wiki.add = behavior.add.bind(behavior);
-		wiki.once = behavior.once.bind(behavior);
-		wiki.update = behavior.update.bind(behavior);
-
-
-		// add core jspwiki behaviors; needed to support the default template jsp's
-		wiki.add( "body", wiki.caniuse )
-
-			.add( "[accesskey]", Accesskey )
-
-			//toggle effect:  toggle .active class on this element when clicking toggle element
-			//.add("[data-toggle]", "onToggle", {attr:"data-toggle"})
-			.add( "[data-toggle]", function(element){
-
-				element.onToggle( element.get("data-toggle"), function(isActive){
-					var pref = element.get("data-toggle-pref");
-					if (pref) {
-						wiki.prefs.set(pref, isActive ? "active" : "");
-					}
-				});
-			})
-
-			//generate modal confirmation boxes, eg prompting to execute
-			//an unrecoverable action such as deleting a page or attachment
-			//.add("[data-modal]", "onModal", {attr:"data-modal"})
-			.add( "[data-modal]", function(element){
-				element.onModal( element.get("data-modal") );
-			})
-
-			//hover effects: show/hide this element when hovering over the parent element
-			//.add("[data-toggle]", "onHover", {attr:"data-hover-parent"})
-			.add( "[data-hover-parent]", function(element){
-				element.onHover( element.get("data-hover-parent") );
-			})
-
-			// Click effect: Similar to hover effect, but triggered on click of an element (e.g. for searchbox)
-			// Defined in the following two blocks
-			.add("body", function (element) {
-				// Close open element if clicked anywhere else
-				jq$(element).click(function (event) {
-					var openParent = jq$('.open-click-parent');
-					if (jq$.contains(openParent, event.target)) return;
-					else if (openParent.length > 0 && jq$.contains(openParent[0], event.target)) return;
-					else openParent.removeClass('open open-click-parent');
-				})
-			})
-
-			.add("[data-click-parent]", function (element) {
-				jq$(element).click(function (event) {
-					var parentSelector = jq$(this).attr('data-click-parent');
-					var parent = jq$(parentSelector);
-					var openParent = jq$('.open-click-parent');
-					// Close already open parents
-					if (!openParent.is(parent)) {
-						openParent.removeClass('open open-click-parent');
-					}
-					if (parent.hasClass('open')) {
-						parent.removeClass('open open-click-parent');
-					} else {
-						parent.addClass('open open-click-parent');
-						if (parent.find('input').length > 0) {
-							parent.find("input:first").focus();
-						}
-					}
-					event.preventDefault();
-					event.stopPropagation();
-					return false;
-				});
-			})
-
-			//resize the "data-resize" elements when dragging this element
-			//.add( "[data-resize]", wiki.resizer.bind(wiki) )
-			.add( "[data-resize]", function(element){
-				wiki.resizer(element, $$(element.get("data-resize")) );
-			})
-
-			//add header scroll-up/down effect
-			.add(".fixed-header > .header", wiki.yoyo)
-
-			//sticky toolbar in the editor
-			.add(".sticky", function (element) {
-				element.onSticky();
-			})
-
-			//highlight previous search query retreived from a cookie or referrer page
-			.add( ".page-content", function(element){
-
-				var previousQuery = "PrevQuery";
-
-				HighlightQuery( element, wiki.prefs.get(previousQuery) );
-				wiki.prefs.erase(previousQuery);
-
-			})
-
-			//activate quick navigation searchbox
-			.add( ".searchbox .dropdown-menu", function(element){
+    version: "haddock04",  //used to validate compatible preference cookies
+
+    initialize: function(){
+
+        var wiki = this,
+            behavior = new Behavior();
+
+        wiki.add = behavior.add.bind(behavior);
+        wiki.once = behavior.once.bind(behavior);
+        wiki.update = behavior.update.bind(behavior);
+
+
+        // add core jspwiki behaviors; needed to support the default template jsp's
+        wiki.add( "body", wiki.caniuse )
+
+            .add( "[accesskey]", Accesskey )
+
+            //toggle effect:  toggle .active class on this element when clicking toggle element
+            //.add("[data-toggle]", "onToggle", {attr:"data-toggle"})
+            .add( "[data-toggle]", function(element){
+
+                element.onToggle( element.get("data-toggle"), function(isActive){
+                    var pref = element.get("data-toggle-pref");
+                    if (pref) {
+                        wiki.prefs.set(pref, isActive ? "active" : "");
+                    }
+                });
+            })
+
+            //generate modal confirmation boxes, eg prompting to execute
+            //an unrecoverable action such as deleting a page or attachment
+            //.add("[data-modal]", "onModal", {attr:"data-modal"})
+            .add( "[data-modal]", function(element){
+                element.onModal( element.get("data-modal") );
+            })
+
+            //hover effects: show/hide this element when hovering over the parent element
+            //.add("[data-toggle]", "onHover", {attr:"data-hover-parent"})
+            .add( "[data-hover-parent]", function(element){
+                element.onHover( element.get("data-hover-parent") );
+            })
+
+            // Click effect: Similar to hover effect, but triggered on click of an element (e.g. for searchbox)
+            // Defined in the following two blocks
+            .add("body", function (element) {
+                // Close open element if clicked anywhere else
+                jq$(element).click(function (event) {
+                    var openParent = jq$('.open-click-parent');
+                    if (jq$.contains(openParent, event.target)) return;
+                    else if (openParent.length > 0 && jq$.contains(openParent[0], event.target)) return;
+                    else openParent.removeClass('open open-click-parent');
+                })
+            })
+
+            .add("[data-click-parent]", function (element) {
+                jq$(element).click(function (event) {
+                    var parentSelector = jq$(this).attr('data-click-parent');
+                    var parent = jq$(parentSelector);
+                    var openParent = jq$('.open-click-parent');
+                    // Close already open parents
+                    if (!openParent.is(parent)) {
+                        openParent.removeClass('open open-click-parent');
+                    }
+                    if (parent.hasClass('open')) {
+                        parent.removeClass('open open-click-parent');
+                    } else {
+                        parent.addClass('open open-click-parent');
+                        if (parent.find('input').length > 0) {
+                            parent.find("input:first").focus();
+                        }
+                    }
+                    event.preventDefault();
+                    event.stopPropagation();
+                    return false;
+                });
+            })
+
+            //resize the "data-resize" elements when dragging this element
+            //.add( "[data-resize]", wiki.resizer.bind(wiki) )
+            .add( "[data-resize]", function(element){
+                wiki.resizer(element, $$(element.get("data-resize")) );
+            })
+
+            //add header scroll-up/down effect
+            .add(".fixed-header > .header", wiki.yoyo)
+
+            //sticky toolbar in the editor
+            .add(".sticky", function (element) {
+                element.onSticky();
+            })
+
+            //highlight previous search query retreived from a cookie or referrer page
+            .add( ".page-content", function(element){
+
+                var previousQuery = "PrevQuery";
+
+                HighlightQuery( element, wiki.prefs.get(previousQuery) );
+                wiki.prefs.erase(previousQuery);
+
+            })
+
+            //activate quick navigation searchbox
+            .add( ".searchbox .dropdown-menu", function(element){
 
-				var recentSearch = "RecentSearch", prefs = wiki.prefs;
+                var recentSearch = "RecentSearch", prefs = wiki.prefs;
 
-				//activate Recent Searches functionality
-				new wiki.Recents( element, {
-					items: prefs.get(recentSearch),
-					onChange: function( items ){
-						items ? prefs.set(recentSearch, items) : prefs.erase(recentSearch);
-					}
-				});
+                //activate Recent Searches functionality
+                new wiki.Recents( element, {
+                    items: prefs.get(recentSearch),
+                    onChange: function( items ){
+                        items ? prefs.set(recentSearch, items) : prefs.erase(recentSearch);
+                    }
+                });
 
-				//activate Quick Navigation functionality
-				new wiki.Findpages(element, {
-					rpc: function(value, callback){
-						wiki.jsonrpc("/search/pages", [value, 16], callback);
-					},
-					toUrl: wiki.toUrl.bind(wiki),
-					allowClone: function(){
-						return /view|preview|info|attach/.test( wiki.Context );
-					}
-				});
-			})
+                //activate Quick Navigation functionality
+                new wiki.Findpages(element, {
+                    rpc: function(value, callback){
+                        wiki.jsonrpc("/search/pages", [value, 16], callback);
+                    },
+                    toUrl: wiki.toUrl.bind(wiki),
+                    allowClone: function(){
+                        return /view|preview|info|attach/.test( wiki.Context );
+                    }
+                });
+            })
 
-			//activate ajax search routines on Search.jsp
-			.add( "#searchform2", function(form){
+            //activate ajax search routines on Search.jsp
+            .add( "#searchform2", function(form){
 
-				wiki.search = new wiki.Search( form, {
-					xhrURL: wiki.XHRSearch,
-					onComplete: function(){
-						//console.log(form.query.get("value"));
-						wiki.prefs.set("PrevQuery", form.query.get("value"));
-					}
-				});
-			})
+                wiki.search = new wiki.Search( form, {
+                    xhrURL: wiki.XHRSearch,
+                    onComplete: function(){
+                        //console.log(form.query.get("value"));
+                        wiki.prefs.set("PrevQuery", form.query.get("value"));
+                    }
+                });
+            })
 
-			//activate attachment upload routines
-			.add( "#files", Form.File, {
-				max: 8,
-				rpc: function(progressid, callback){
-					//console.log("progress", progressid);
-					wiki.jsonrpc("/progressTracker", [progressid], callback);
-				}
-			});
+            //activate attachment upload routines
+            .add( "#files", Form.File, {
+                max: 8,
+                rpc: function(progressid, callback){
+                    //console.log("progress", progressid);
+                    wiki.jsonrpc("/progressTracker", [progressid], callback);
+                }
+            });
 
-		window.addEvents({
-			popstate: wiki.popstate,
-			domready: wiki.domready.bind(wiki)
-		});
+        window.addEvents({
+            popstate: wiki.popstate,
+            domready: wiki.domready.bind(wiki)
+        });
 
-	},
+    },
 
 
-	caniuse: function( body ){
+    caniuse: function( body ){
 
-		//support for flexbox is broken in IE, do it the hard-way - ugh.
+        //support for flexbox is broken in IE, do it the hard-way - ugh.
 
-		var isIE11 = !(window.ActiveXObject) && "ActiveXObject" in window;
-		var isIE9or10 = "ActiveXObject" in window;
+        var isIE11 = !(window.ActiveXObject) && "ActiveXObject" in window;
+        var isIE9or10 = "ActiveXObject" in window;
 
-		body.ifClass( !( isIE11 || isIE9or10 ) , "can-flex");
+        body.ifClass( !( isIE11 || isIE9or10 ) , "can-flex");
 
-	},
+    },
 
 
-	/*
-	Function: domready
-		After the DOM is fully loaded:
-		- initialize the meta data wiki properties
-		- initialize the section Links
-		- when the "referrer" url (previous page) contains a "section=" parameter,
-		  scroll the wiki page to the right section
-	*/
-	domready: function(){
+    /*
+    Function: domready
+        After the DOM is fully loaded:
+        - initialize the meta data wiki properties
+        - initialize the section Links
+        - when the "referrer" url (previous page) contains a "section=" parameter,
+          scroll the wiki page to the right section
+    */
+    domready: function(){
 
-		var wiki = this;
+        var wiki = this;
 
-		wiki.dropdowns();
+        wiki.dropdowns();
 
-		wiki.meta();
+        wiki.meta();
 
-		wiki.prefs = new Hash.Cookie("JSPWikiUserPrefs", {
-			path: wiki.BasePath,
-			duration: 20
-		});
+        wiki.prefs = new Hash.Cookie("JSPWikiUserPrefs", {
+            path: wiki.BasePath,
+            duration: 20
+        });
 
-		//Object.each(wiki.prefs.hash, function(item,key){ console.log("PREFS  ",key,"=>",item); });
+        //Object.each(wiki.prefs.hash, function(item,key){ console.log("PREFS  ",key,"=>",item); });
 
-		if( wiki.version != wiki.prefs.get("version") ){
-			wiki.prefs.empty();
-			wiki.prefs.set("version", wiki.version);
-		}
+        if( wiki.version != wiki.prefs.get("version") ){
+            wiki.prefs.empty();
+            wiki.prefs.set("version", wiki.version);
+        }
 
-		//The initial Sidebar will be active depending on a cookie state.
-		//However, for small screen,  the default state will be hidden.
-		wiki.media("(min-width:768px)", function( screenIsLarge ){
+        //The initial Sidebar will be active depending on a cookie state.
+        //However, for small screen,  the default state will be hidden.
+        wiki.media("(min-width:768px)", function( screenIsLarge ){
 
-			if(!screenIsLarge){
-				$$(".content")[0].removeClass("active"); //always hide sidebar on pageload for narrow screens
-			}
+            if(!screenIsLarge){
+                $$(".content")[0].removeClass("active"); //always hide sidebar on pageload for narrow screens
+            }
 
-		});
+        });
 
-		//wiki.url = null;  //CHECK:  why this is needed?
-		//console.log( wiki.prefs.get("SectionEditing") , wiki.EditPermission ,wiki.Context );
-		if( wiki.prefs.get("SectionEditing") && wiki.EditPermission && (wiki.Context != "preview") ){
+        //wiki.url = null;  //CHECK:  why this is needed?
+        //console.log( wiki.prefs.get("SectionEditing") , wiki.EditPermission ,wiki.Context );
+        if( wiki.prefs.get("SectionEditing") && wiki.EditPermission && (wiki.Context != "preview") ){
 
-			wiki.addEditLinks( wiki.toUrl( wiki.PageName, true ) );
+            wiki.addEditLinks( wiki.toUrl( wiki.PageName, true ) );
 
-		}
+        }
 
-		//console.log( "section", document.referrer, document.referrer.match( /\&section=(\d+)$/ ) );
-		wiki.scrollTo( ( document.referrer.match( /\&section=(\d+)$/ ) || [,-1])[1] );
+        //console.log( "section", document.referrer, document.referrer.match( /\&section=(\d+)$/ ) );
+        wiki.scrollTo( ( document.referrer.match( /\&section=(\d+)$/ ) || [,-1])[1] );
 
-		// initialize all registered behaviors
-		wiki.update();
+        // initialize all registered behaviors
+        wiki.update();
 
-		//on page-load, also read the #hash and fire popstate events
-		wiki.popstate();
+        //on page-load, also read the #hash and fire popstate events
+        wiki.popstate();
 
-		wiki.autofocus();
+        wiki.autofocus();
 
-	},
+    },
 
 
-	/*
-	Function: media query event handler
-		Catch media-query changes  (eg screen width,  portrait/landscape changes,  etc...
-	*/
-	media: function(query, callback){
+    /*
+    Function: media query event handler
+        Catch media-query changes  (eg screen width,  portrait/landscape changes,  etc...
+    */
+    media: function(query, callback){
 
-		function queryChanged( event ){ callback( event.matches ); }
+        function queryChanged( event ){ callback( event.matches ); }
 
-		if( /*window.*/ matchMedia ){
+        if( /*window.*/ matchMedia ){
 
-			var mediaQueryList = matchMedia( query );
-			mediaQueryList.addListener( queryChanged );
-			queryChanged( mediaQueryList );
-		}
+            var mediaQueryList = matchMedia( query );
+            mediaQueryList.addListener( queryChanged );
+            queryChanged( mediaQueryList );
+        }
 
-	},
+    },
 
-	/*
-	Function: yoyo ( header )
-		Add a yoyo effect to the header:  hide it on scroll down, show it again on scroll up.
+    /*
+    Function: yoyo ( header )
+        Add a yoyo effect to the header:  hide it on scroll down, show it again on scroll up.
 
-	Inspired by: https://github.com/WickyNilliams/headroom.js
+    Inspired by: https://github.com/WickyNilliams/headroom.js
 
-	DOM Structure:
-	(start code)
-		div[style='padding-top:nn']    => nn==height of header;  push content down
-		div.header.yoyo[.scrolling-down]  => css: position=fixed
-	(end)
+    DOM Structure:
+    (start code)
+        div[style='padding-top:nn']    => nn==height of header;  push content down
+        div.header.yoyo[.scrolling-down]  => css: position=fixed
+    (end)
 
-	*/
-	yoyo: function( header ){
+    */
+    yoyo: function( header ){
 
-		var height = "offsetHeight",
-			scrollY,
-			lastScrollY = 0,
+        var height = "offsetHeight",
+            scrollY,
+            lastScrollY = 0,
 
-			//add spacer just infront of fixed element,
-			//and adjust height == header (fixed elements do not take space in the dom)
-			spacer = "div".slick().inject(header, "before"),
-			busy;
+            //add spacer just infront of fixed element,
+            //and adjust height == header (fixed elements do not take space in the dom)
+            spacer = "div".slick().inject(header, "before"),
+            busy;
 
-		function update(){
+        function update(){
 
-			scrollY = window.getScroll().y;
+            scrollY = window.getScroll().y;
 
-			spacer.style.paddingTop = header[height]+"px"; //update after window resize
+            spacer.style.paddingTop = header[height]+"px"; //update after window resize
 
-			// Limit scroll top to counteract iOS / OSX bounce.
-			scrollY = scrollY.limit(0, window.getScrollSize().y - window.getSize().y);
+            // Limit scroll top to counteract iOS / OSX bounce.
+            scrollY = scrollY.limit(0, window.getScrollSize().y - window.getSize().y);
 
-			if (Math.abs(lastScrollY - scrollY) > 5 /* minimum difference */) {
+            if (Math.abs(lastScrollY - scrollY) > 5 /* minimum difference */) {
 
-				header.ifClass(scrollY > lastScrollY && scrollY > header[height], "scrolling-down");
-				lastScrollY = scrollY;
+                header.ifClass(scrollY > lastScrollY && scrollY > header[height], "scrolling-down");
+                lastScrollY = scrollY;
 
-			}
-			busy = false;
-		}
+            }
+            busy = false;
+        }
 
-		function handleEvent(){
-			if(!busy){
-				busy = true;
-				requestAnimationFrame( update );
-			}
-		}
+        function handleEvent(){
+            if(!busy){
+              busy = true;
+              requestAnimationFrame( update );
+            }
+        }
 
-		window.addEvents({ scroll: handleEvent, resize: handleEvent });
-		update(); //first run: set height of the spacer
+        window.addEvents({ scroll: handleEvent, resize: handleEvent });
+        update(); //first run: set height of the spacer
 
-	},
+    },
 
 
-	/*
-	Function: popstate
-		When pressing the back-button, the "popstate" event is fired.
-		This popstate function will fire a internal 'popstate' event
-		on the target DOM element.
+    /*
+    Function: popstate
+        When pressing the back-button, the "popstate" event is fired.
+        This popstate function will fire a internal 'popstate' event
+        on the target DOM element.
 
-		Behaviors (such as Tabs or Accordions) can push the ID of their
-		visible content on the window.location hash.
-		This ID can be retrieved when the back-button is pressed.
+        Behaviors (such as Tabs or Accordions) can push the ID of their
+        visible content on the window.location hash.
+        This ID can be retrieved when the back-button is pressed.
 
-		When clicking a link referring to hidden content (tab, accordion), the
-		popstate event is 'bubbled' up the DOM tree.
+        When clicking a link referring to hidden content (tab, accordion), the
+        popstate event is 'bubbled' up the DOM tree.
 
-	*/
-	popstate: function(){
+    */
+    popstate: function(){
 
-		var target = $(location.hash.slice(1)),
-			events,
-			popstate = "popstate";
+        var target = $(location.hash.slice(1)),
+            events,
+            popstate = "popstate";
 
-		//console.log( popstate, location.hash, target );
+        //console.log( popstate, location.hash, target );
 
-		//only send popstate events to targets within the main page; eg not sidebar
-		if( target && target.getParent(".page-content") ){
+        //only send popstate events to targets within the main page; eg not sidebar
+        if( target && target.getParent(".page-content") ){
 
-			while( !target.hasClass("page-content") ){
+            while( !target.hasClass("page-content") ){
 
-				events = target.retrieve("events"); //mootools specific - to read registered events on elements
+                events = target.retrieve("events"); //mootools specific - to read registered events on elements
 
-				if( events && events[popstate] ){
+                if( events && events[popstate] ){
 
-					target.fireEvent(popstate);
+                    target.fireEvent(popstate);
 
-				}
+                }
 
-				target = target.getParent();
+                target = target.getParent();
 
-			}
-		}
-	},
+            }
+        }
+    },
 
-	autofocus: function(){
+    autofocus: function(){
 
-		var els, element;
+        var els, element;
 
-		if( !("autofocus" in document.createElement("input") ) ){
-			// editor/plain.jsp  textarea#wikiText
-			// login.jsp         input#j_username
-			// prefs/prefs       input#assertedName
-			// find              input#query2
-			els = $$("input[autofocus=autofocus], textarea[autofocus=autofocus]");
-			while( els[0] ){
-				element = els.shift();
-				//console.log("autofocus", element, element.autofocus, element.isVisible(), element.offsetWidth, element.offsetHeight, "$", element.getStyle("display"), "$");
-				if( element.isVisible() ){
-					element.focus();
-					return;
-				}
-			}
-		}
+        if( !("autofocus" in document.createElement("input") ) ){
+            // editor/plain.jsp  textarea#wikiText
+            // login.jsp         input#j_username
+            // prefs/prefs       input#assertedName
+            // find              input#query2
+            els = $$("input[autofocus=autofocus], textarea[autofocus=autofocus]");
+            while( els[0] ){
+                element = els.shift();
+                //console.log("autofocus", element, element.autofocus, element.isVisible(), element.offsetWidth, element.offsetHeight, "$", element.getStyle("display"), "$");
+                if( element.isVisible() ){
+                    element.focus();
+                    return;
+                }
+            }
+        }
 
-	},
+    },
 
-	/*
-	Function: meta
-		Read all the "meta" dom elements, prefixed with "wiki",
-		and add them as properties to the wiki object.
-		EG  <meta name="wikiContext">  becomes  wiki.Context
-		* wikiContext : jspwiki requestcontext variable (view, edit, info, ...)
-		* wikiBaseUrl
-		* wikiPageUrl: page url template with dummy pagename "%23%24%25"
-		* wikiEditUrl : edit page url
-		* wikiJsonUrl : JSON-RPC / AJAX url
-		* wikiPageName : pagename without blanks
-		* wikiUserName
-		* wikiTemplateUrl : path of the jsp template
-		* wikiApplicationName
-		* wikiEditPermission
-	*/
-	meta: function(){
+    /*
+    Function: meta
+        Read all the "meta" dom elements, prefixed with "wiki",
+        and add them as properties to the wiki object.
+        EG  <meta name="wikiContext">  becomes  wiki.Context
+        * wikiContext : jspwiki requestcontext variable (view, edit, info, ...)
+        * wikiBaseUrl
+        * wikiPageUrl: page url template with dummy pagename "%23%24%25"
+        * wikiEditUrl : edit page url
+        * wikiJsonUrl : JSON-RPC / AJAX url
+        * wikiPageName : pagename without blanks
+        * wikiUserName
+        * wikiTemplateUrl : path of the jsp template
+        * wikiApplicationName
+        * wikiEditPermission
+    */
+    meta: function(){
 
-		var url,
-			wiki = this,
-			host = location.host;
+        var url,
+            wiki = this,
+            host = location.host;
 
-		$$("meta[name^=wiki]").each( function(el){
-			wiki[el.get("name").slice(4)] = el.get("content") || "";
-		});
+        $$("meta[name^=wiki]").each( function(el){
+            wiki[el.get("name").slice(4)] = el.get("content") || "";
+        });
 
-		// BasePath: if JSPWiki is installed in the root, then we have to make sure that
-		// the cookie-cutter works properly here.
-		url = wiki.BaseUrl;
-		url = url ? url.slice(url.indexOf(host) + host.length, -1) : "";
-		wiki.BasePath = (url /*===""*/) ? url : "/";
-		//console.log(url, host, wiki.BaseUrl + " basepath: " + wiki.BasePath);
+        // BasePath: if JSPWiki is installed in the root, then we have to make sure that
+        // the cookie-cutter works properly here.
+        url = wiki.BaseUrl;
+        url = url ? url.slice(url.indexOf(host) + host.length, -1) : "";
+        wiki.BasePath = (url /*===""*/) ? url : "/";
+        //console.log(url, host, wiki.BaseUrl + " basepath: " + wiki.BasePath);
 
-	},
+    },
 
-	/*
-	Function: dropdowns
-		Parse special wikipages such ase MoreMenu, HomeMenu
-		and format them as bootstrap compatible dropdown menus.
-	*/
-	dropdowns: function(){
+    /*
+    Function: dropdowns
+        Parse special wikipages such ase MoreMenu, HomeMenu
+        and format them as bootstrap compatible dropdown menus.
+    */
+    dropdowns: function(){
 
-		$$( "ul.dropdown-menu > li > ul" ).each( function(ul){
+        $$( "ul.dropdown-menu > li > ul" ).each( function(ul){
 
-			var li, parentLi = ul.getParent();
+            var li, parentLi = ul.getParent();
 
-			while( (li = ul.getFirst("li")) ){
+            while( (li = ul.getFirst("li")) ){
 
-				if( li.innerHTML.trim() == "----" ){
+                if( li.innerHTML.trim() == "----" ){
 
-					li.addClass("divider");
+                    li.addClass("divider");
 
-				} else if( !li.getFirst() || !li.getFirst("a") ){
+                } else if( !li.getFirst() || !li.getFirst("a") ){
 
-					li.addClass("dropdown-header");
+                    li.addClass("dropdown-header");
 
-				}
-				li.inject(parentLi, "before");
+                }
+                li.inject(parentLi, "before");
 
-			}
-			ul.dispose();
+            }
+            ul.dispose();
 
-		});
+        });
 
-		/* (deprecated) "pre-HADDOCK" moremenu style
-			  Consists of a list of links, with \\ delimitters
-			  Each <p> becomes a set of <li>, one for each link
-			  The block is terminated with a divider, if more <p>'s are coming
-		*/
-		$$( "ul.dropdown-menu > li.more-menu > p" ).each( function(element){
+        /* (deprecated) "pre-HADDOCK" moremenu style
+              Consists of a list of links, with \\ delimitters
+              Each <p> becomes a set of <li>, one for each link
+              The block is terminated with a divider, if more <p>'s are coming
+        */
+        $$( "ul.dropdown-menu > li.more-menu > p" ).each( function(element){
 
-			var parentLi = element.getParent();
+            var parentLi = element.getParent();
 
-			element.getElements('a').each( function(link){
-				["li",[link]].slick().inject(parentLi, "before");
-			});
-			if( element.getNext("p *,hr") ){
-				"li.divider".slick().inject(parentLi, "before") ;
-			}
-			element.dispose();
+            element.getElements('a').each( function(link){
+                ["li",[link]].slick().inject(parentLi, "before");
+            });
+            if( element.getNext("p *,hr") ){
+                "li.divider".slick().inject(parentLi, "before") ;
+            }
+            element.dispose();
 
-		});
+        });
 
-	},
+    },
 
-	/*
-	Function: getSections
-		Returns the list of all section headers, excluding the header of the Table Of Contents.
-	*/
-	getSections: function(){
+    /*
+    Function: getSections
+        Returns the list of all section headers, excluding the header of the Table Of Contents.
+    */
+    getSections: function(){
 
-		return $$(".page-content [id^=section]:not(#section-TOC)");
+        return $$(".page-content [id^=section]:not(#section-TOC)");
 
-	},
+    },
 
-	/*
-	Function: scrollTo
-		Scrolls the page to the section previously being edited - if any
-		Section counting starts at 1??
-	*/
-	scrollTo: function( index ){
+    /*
+    Function: scrollTo
+        Scrolls the page to the section previously being edited - if any
+        Section counting starts at 1??
+    */
+    scrollTo: function( index ){
 
-		//console.log("Scroll to section ", index, ", Number of sections:", this.getSections().length );
-		var element = this.getSections()[index];
+        //console.log("Scroll to section ", index, ", Number of sections:", this.getSections().length );
+        var element = this.getSections()[index];
 
-		if( element ){
-			location.replace( "#" + element.get("id") );
-		}
+        if( element ){
+            location.replace( "#" + element.get("id") );
+        }
 
-	},
+    },
 
-	/*
-	Property: toUrl
-		Convert a wiki pagename to a full wiki-url.
-		Use the correct url template: view(default), edit-url or clone-url
-	*/
-	toUrl: function(pagename, isEdit, isClone){
+    /*
+    Property: toUrl
+        Convert a wiki pagename to a full wiki-url.
+        Use the correct url template: view(default), edit-url or clone-url
+    */
+    toUrl: function(pagename, isEdit, isClone){
 
-		var urlTemplate = isClone ? this.CloneUrl : isEdit ? this.EditUrl : this.PageUrl;
-		return urlTemplate.replace(/%23%24%25/, this.cleanPageName(pagename) );
+        var urlTemplate = isClone ? this.CloneUrl : isEdit ? this.EditUrl : this.PageUrl;
+        return urlTemplate.replace(/%23%24%25/, this.cleanPageName(pagename) );
 
-	},
+    },
 
-	/*
-	Property: toPageName
-		Parse a wiki-url and return the corresponding wiki pagename
-	*/
-	toPageName: function(url){
+    /*
+    Property: toPageName
+        Parse a wiki-url and return the corresponding wiki pagename
+    */
+    toPageName: function(url){
 
-		var s = this.PageUrl.escapeRegExp().replace(/%23%24%25/, "(.+)");
-		return ( url.match( RegExp(s) ) || [0, false] )[1];
+        var s = this.PageUrl.escapeRegExp().replace(/%23%24%25/, "(.+)");
+        return ( url.match( RegExp(s) ) || [0, false] )[1];
 
-	},
+    },
 
-	/*
-	Property: cleanPageName
-		Remove all not-allowed chars from a pagename.
-		Trim all whitespace, allow letters, digits and punctuation chars: ()&+, -=._$
-		Mirror of org.apache.wiki.parser.MarkupParser.cleanPageName()
-	*/
-	cleanPageName: function( pagename ){
+    /*
+    Property: cleanPageName
+        Remove all not-allowed chars from a pagename.
+        Trim all whitespace, allow letters, digits and punctuation chars: ()&+, -=._$
+        Mirror of org.apache.wiki.parser.MarkupParser.cleanPageName()
+    */
+    cleanPageName: function( pagename ){
 
-		//\w is short for [A-Z_a-z0-9_]
-		return pagename.clean().replace(/[^\w\u00C0-\u1FFF\u2800-\uFFFD\(\)&\+,\-=\.\$ ]/g, "");
+        //\w is short for [A-Z_a-z0-9_]
+        return pagename.clean().replace(/[^\w\u00C0-\u1FFF\u2800-\uFFFD\(\)&\+,\-=\.\$ ]/g, "");
 
-	},
+    },
 
-	/*
-	Function: addEditLinks
-		Add to each Section title (h2/h3/h4) a quick edit link.
-		FFS: should better move server side
-		FFS: add section #hash to automatically go back to the section being edited
-	*/
-	addEditLinks: function( url ){
+    /*
+    Function: addEditLinks
+        Add to each Section title (h2/h3/h4) a quick edit link.
+        FFS: should better move server side
+        FFS: add section #hash to automatically go back to the section being edited
+    */
+    addEditLinks: function( url ){
 
-		var description = "quick.edit".localize();
+        var description = "quick.edit".localize();
 
-		url = url + (url.contains("?") ? "&" : "?") + "section=";
+        url = url + (url.contains("?") ? "&" : "?") + "section=";
 
-		this.getSections().each( function(element, index){
+        this.getSections().each( function(element, index){
 
-			element.grab("a.editsection".slick({ html: description, href: url + index }));
+            element.grab("a.editsection".slick({ html: description, href: url + index }));
 
-		});
+        });
 
-	},
+    },
 
-	/*
-	Function: configPrefs  (sofar only used in edit mode)
-		Initialize the configuration checkboxes from the wiki prefs cookie.
-		Save any change to the checkboxes back into the wiki prefs cookie.
-		Also take care of switching between different editor types, saving the
-		new editor type into the wiki prefs cookie.
+    /*
+    Function: configPrefs  (sofar only used in edit mode)
+        Initialize the configuration checkboxes from the wiki prefs cookie.
+        Save any change to the checkboxes back into the wiki prefs cookie.
+        Also take care of switching between different editor types, saving the
+        new editor type into the wiki prefs cookie.
 
-		EG: tabcompletion, smartpairs, autosuggest, livepreview, previewcolumn. editor-type
-	*/
-	configPrefs: function( form, onChangeFn ){
+        EG: tabcompletion, smartpairs, autosuggest, livepreview, previewcolumn. editor-type
+    */
+    configPrefs: function( form, onChangeFn ){
 
-		var wiki = this;
+        var wiki = this;
 
-		function onCheck(){
+        function onCheck(){
 
-			var cmd = this.getAttribute("data-cmd"),
-				isChecked = this.checked;
+            var cmd = this.getAttribute("data-cmd"),
+                isChecked = this.checked;
 
-			wiki.toggleLivePreview(form, cmd, isChecked);
-			wiki.prefs.set(cmd, isChecked);  //persist in the pref cookie
-			if( onChangeFn ){ onChangeFn(cmd, isChecked); }
+            wiki.toggleLivePreview(form, cmd, isChecked);
+            wiki.prefs.set(cmd, isChecked);  //persist in the pref cookie
+            if( onChangeFn ){ onChangeFn(cmd, isChecked); }
 
-		}
+        }
 
-		//Handle all configuration checkboxes
-		form.getElements("[type=checkbox][data-cmd]").each( function( el ){
+        //Handle all configuration checkboxes
+        form.getElements("[type=checkbox][data-cmd]").each( function( el ){
 
-			el.checked = !!wiki.prefs.get(el.getAttribute("data-cmd"));
-			el.addEvent("click", onCheck );
-			onCheck.apply(el);
+            el.checked = !!wiki.prefs.get(el.getAttribute("data-cmd"));
+            el.addEvent("click", onCheck );
+            onCheck.apply(el);
 
-		});
+        });
 
-		//Persist the selected editor type in the pref cookie
-		form.getElements("a.editor-type").addEvent("click", function(){
+        //Persist the selected editor type in the pref cookie
+        form.getElements("a.editor-type").addEvent("click", function(){
 
-			wiki.prefs.set("editor", this.get("text"));
+            wiki.prefs.set("editor", this.get("text"));
 
-		});
+        });
 
-	},
+    },
 
 
-	toggleLivePreview: function( container, cmd, state ){
+    toggleLivePreview: function( container, cmd, state ){
 
-		if( cmd.test( /livepreview|previewcolumn/ ) ){
+        if( cmd.test( /livepreview|previewcolumn/ ) ){
 
-			var previewcontainer = container.getElement(".edit-area").ifClass(state, cmd),
-				ajaxpreview = container.getElement(".ajaxpreview");
+            var previewcontainer = container.getElement(".edit-area").ifClass(state, cmd),
+                ajaxpreview = container.getElement(".ajaxpreview");
 
-			if( cmd == "livepreview" ){
+            if( cmd == "livepreview" ){
 
-				//disable the previewcolumn toolbar cmd checkbox
-				container.getElement("[data-cmd=previewcolumn]").disabled = !state;
+                //disable the previewcolumn toolbar cmd checkbox
+                container.getElement("[data-cmd=previewcolumn]").disabled = !state;
 
-			} else {
+            } else {
 
-				/* Toggle the position of the preview-area in the dom
+                /* Toggle the position of the preview-area in the dom
 
-				1. HORIZONTAL SIDE BY SIDE VIEW
-				div.snip
-					div.toolbar
-					div.edit-area.livepreview.previewcolumn
-						div.col-50
-						div.col-50.ajaxpreview
-					div.resizer
+                1. HORIZONTAL SIDE BY SIDE VIEW
+                div.snip
+                    div.toolbar
+                    div.edit-area.livepreview.previewcolumn
+                        div.col-50
+                        div.col-50.ajaxpreview
+                    div.resizer
 
-				2. VERTICAL VIEW
-				div.snip
-					div.toolbar
-					div.edit-area.livepreview
-						div.col-50
-					div.resizer
-					div.col-50.ajaxpreview
-				*/
+                2. VERTICAL VIEW
+                div.snip
+                    div.toolbar
+                    div.edit-area.livepreview
+                        div.col-50
+                    div.resizer
+                    div.col-50.ajaxpreview
+                */
 
-				if( !state ){ previewcontainer = previewcontainer.getParent(); }
-				previewcontainer.grab(ajaxpreview);
+                if( !state ){ previewcontainer = previewcontainer.getParent(); }
+                previewcontainer.grab(ajaxpreview);
 
-			}
-		}
-	},
+            }
+        }
+    },
 
-	getXHRPreview: function( getContent, previewElement ){
+    getXHRPreview: function( getContent, previewElement ){
 
-		var wiki = this,
-			loading = "loading",
-			preview = function(p){ previewElement.removeClass(loading).set("text", p);};
+        var wiki = this,
+            loading = "loading",
+            preview = function(p){ previewElement.removeClass(loading).set("text", p);};
 
-		return (function(){
+        return (function(){
 
-			previewElement.addClass(loading);
+            previewElement.addClass(loading);
 
-			new Request({
-				url: wiki.XHRHtml2Markup,
-				data: {
-					htmlPageText: getContent()
-				},
-				onSuccess: function(responseText){
-					preview( responseText.trim() );
-				},
-				onFailure: function(e){
-					preview( "Sorry, HTML to Wiki Markup conversion failed :=() " + e );
-				}
-			}).send();
+            new Request({
+                url: wiki.XHRHtml2Markup,
+                data: {
+                    htmlPageText: getContent()
+                },
+                onSuccess: function(responseText){
+                    preview( responseText.trim() );
+                },
+                onFailure: function(e){
+                    preview( "Sorry, HTML to Wiki Markup conversion failed :=() " + e );
+                }
+            }).send();
 
-		}).debounce();
+        }).debounce();
 
-	},
+    },
 
-	/*
-	Behavior: resizer
-		Resize the target element, by dragging a .resizer handle.
-		Multiple elements can be resized via the callback.
-		The .resizer element can specify a prefs cookie to retrieve/store the height.
-		Used by the plain and wysiwyg editor.
+    /*
+    Behavior: resizer
+        Resize the target element, by dragging a .resizer handle.
+        Multiple elements can be resized via the callback.
+        The .resizer element can specify a prefs cookie to retrieve/store the height.
+        Used by the plain and wysiwyg editor.
 
-	Arguments:
-		target - DOM element to be resized
-		callback - function, to allow resizing of more elements
+    Arguments:
+        target - DOM element to be resized
+        callback - function, to allow resizing of more elements
 
-	Globals:
-		wiki - main wiki object, to get/set preference fields
-		textarea - resizable textarea (DOM element)
-		preview - preview (DOM element)
-	*/
-	/*
-	wiki.add(".resizer",function(element){...}
+    Globals:
+        wiki - main wiki object, to get/set preference fields
+        textarea - resizable textarea (DOM element)
+        preview - preview (DOM element)
+    */
+    /*
+    wiki.add(".resizer",function(element){...}
 
 
-	[data-resize] : resize target,  can be multiple elements
+    [data-resize] : resize target,  can be multiple elements
 
-	div.resizer[data-resize=".pagecontent"] => for add-comment sections
-	div.resizer[data-resize=".ajaxpreview,.snipeable"][data-pref=editorHeight]
-	*/
-	resizer: function( handle, targets, dragCallback ){
+    div.resizer[data-resize=".pagecontent"] => for add-comment sections
+    div.resizer[data-resize=".ajaxpreview,.snipeable"][data-pref=editorHeight]
+    */
+    resizer: function( handle, targets, dragCallback ){
 
-		var pref = handle.get("data-pref"),
-			prefs = this.prefs,
-			target;
+        var pref = handle.get("data-pref"),
+            prefs = this.prefs,
+            target;
 
-		function showDragState(add){ handle.ifClass(add, "dragging"); }
+        function showDragState(add){ handle.ifClass(add, "dragging"); }
 
-		if( !targets[0] ){ return; }
+        if( !targets[0] ){ return; }
 
-		//set the initial size of the targets
-		if( pref ){
-			targets.setStyle("height", prefs.get(pref) || 300 );
-		}
+        //set the initial size of the targets
+        if( pref ){
+            targets.setStyle("height", prefs.get(pref) || 300 );
+        }
 
-		target = targets.pop();
+        target = targets.pop();
 
-		target.makeResizable({
-			handle: handle,
-			modifiers: { x: null },
-			onDrag: function(){
-				var h = this.value.now.y;
-				if( pref ){ prefs.set(pref, h); }
-				if( targets ){ targets.setStyle("height", h); }
-				if( dragCallback ){ dragCallback(h); }
-			},
-			onBeforeStart: showDragState.pass(true),
-			onComplete: showDragState.pass(false),
-			onCancel: showDragState.pass(false)
-		});
+        target.makeResizable({
+            handle: handle,
+            modifiers: { x: null },
+            onDrag: function(){
+                var h = this.value.now.y;
+                if( pref ){ prefs.set(pref, h); }
+                if( targets ){ targets.setStyle("height", h); }
+                if( dragCallback ){ dragCallback(h); }
+            },
+            onBeforeStart: showDragState.pass(true),
+            onComplete: showDragState.pass(false),
+            onCancel: showDragState.pass(false)
+        });
 
-	},
+    },
 
 
-	pageDialog: function( caption, method ){
+    pageDialog: function( caption, method ){
 
-		var wiki = this;
+        var wiki = this;
 
-		return [ Dialog.Selection, {
+        return [ Dialog.Selection, {
 
-			caption: caption,
+            caption: caption,
 
-			onOpen: function( dialog ){
+            onOpen: function( dialog ){
 
-				var key = dialog.getValue();
+                var key = dialog.getValue();
 
-				//if empty link, than fetch list of attachments of the open page
-				if( !key || (key.trim()=='') ){
+                //if empty link, than fetch list of attachments of the open page
+                if( !key || (key.trim()=='') ){
 
-					key = wiki.PageName + "/";
+                    key = wiki.PageName + "/";
 
-				}
+                }
 
-				wiki.jsonrpc( method, [key, 30], function( result ){
+                wiki.jsonrpc( method, [key, 30], function( result ){
 
-					//console.log("jsonrpc result", result, !!result[0] );
-					if( result[0] /* length > 0 */ ){
+                    //console.log("jsonrpc result", result, !!result[0] );
+                    if( result[0] /* length > 0 */ ){
 
-						dialog.setBody( result );
+                        dialog.setBody( result );
 
-					} else {
+                    } else {
 
-						dialog.hide();
+                        dialog.hide();
 
-					}
-				});
-			}
-		}];
+                    }
+                });
+            }
+        }];
 
-	},
+    },
 
-	/*
-	Function: jsonrpc
-		Generic json-rpc routines to talk to the backend jspwiki-engine.
-	Note:
-		Uses the JsonUrl which is read from the meta element "WikiJsonUrl"
-		{{{ <meta name="wikiJsonUrl" content="/JSPWiki-pipo/JSON-RPC" /> }}}
+    /*
+    Function: jsonrpc
+        Generic json-rpc routines to talk to the backend jspwiki-engine.
+    Note:
+        Uses the JsonUrl which is read from the meta element "WikiJsonUrl"
+        {{{ <meta name="wikiJsonUrl" content="/JSPWiki-pipo/JSON-RPC" /> }}}
 
-	Supported rpc calls:
-		- {{search.findPages}} gets the list of pagenames with partial match
-		- {{progressTracker.getProgress}} get a progress indicator of attachment upload
-		- {{search.getSuggestions}} gets the list of pagenames with partial match
+    Supported rpc calls:
+        - {{search.findPages}} gets the list of pagenames with partial match
+        - {{progressTracker.getProgress}} get a progress indicator of attachment upload
+        - {{search.getSuggestions}} gets the list of pagenames with partial match
 
-	Example:
-		(start code)
-		//Wiki.ajaxJsonCall('/search/pages,[Janne,20]', function(result){
-		Wiki.jsonrpc("search.findPages", ["Janne", 20], function(result){
-			//do something with the resulting json object
-		});
-		(end)
-	*/
-	jsonrpc: function(method, params, callback){
+    Example:
+        (start code)
+        //Wiki.ajaxJsonCall('/search/pages,[Janne,20]', function(result){
+        Wiki.jsonrpc("search.findPages", ["Janne", 20], function(result){
+            //do something with the resulting json object
+        });
+        (end)
+    */
+    jsonrpc: function(method, params, callback){
 
-		if( this.JsonUrl ){
+        if( this.JsonUrl ){
 
-			//console.log(method, JSON.stringify(params) );
+            //console.log(method, JSON.stringify(params) );
 
-			//NOTE:  this is half a JSON rpc ... only responseText is JSON formatted
-			new Request({
-				url: this.JsonUrl + method,
-				//method:"post"     //defaults to "POST"
-				//urlEncoded: true, //content-type header = www-form-urlencoded + encoding
-				//encoding: "utf-8",
-				//encoding: "ISO-8859-1",
-				headers: {
-					//'X-Requested-With': 'XMLHttpRequest',
-					//'Accept': 'text/javascript, text/html, application/xml, text/xml, */*'
-					'Accept': 'application/json',
-					'X-Request': 'JSON'
-				},
-				onSuccess: function( responseText ){
+            //NOTE:  this is half a JSON rpc ... only responseText is JSON formatted
+            new Request({
+                url: this.JsonUrl + method,
+                //method:"post"     //defaults to "POST"
+                //urlEncoded: true, //content-type header = www-form-urlencoded + encoding
+                //encoding: "utf-8",
+                //encoding: "ISO-8859-1",
+        		headers: {
+		        	//'X-Requested-With': 'XMLHttpRequest',
+			        //'Accept': 'text/javascript, text/html, application/xml, text/xml, */*'
+        			'Accept': 'application/json',
+		        	'X-Request': 'JSON'
+		        },
+                onSuccess: function( responseText ){
 
-					//console.log(responseText, JSON.parse( responseText ), responseText.charCodeAt(8),responseText.codePointAt(8), (encodeURIComponent(responseText)), encodeURIComponent("ä"), encodeURIComponent("Ã")  );
-					callback(responseText == "" ? "" : JSON.parse(responseText));
-					//callback( responseText );
+                    //console.log(responseText, JSON.parse( responseText ), responseText.charCodeAt(8),responseText.codePointAt(8), (encodeURIComponent(responseText)), encodeURIComponent("ä"), encodeURIComponent("Ã")  );
+                    callback(responseText == "" ? "" : JSON.parse(responseText));
+                    //callback( responseText );
 
-				},
-				onError: function(error){
-					//console.log(error);
-					callback( null );
-					throw new Error("Wiki rpc error: " + error);
-				}
+                },
+                onError: function(error){
+                    //console.log(error);
+                    callback( null );
+                    throw new Error("Wiki rpc error: " + error);
+                }
 
-			}).send( "params=" + params );
+            }).send( "params=" + params );
 
-		}
+        }
 
-	}
+    }
 
 };
 

--- a/jspwiki-war/src/main/webapp/templates/haddock/SearchBox.jsp
+++ b/jspwiki-war/src/main/webapp/templates/haddock/SearchBox.jsp
@@ -28,9 +28,9 @@
   id="searchForm"
   accept-charset="<wiki:ContentEncoding />">
 
-  <div class="btn"><span class="icon-search"></span><span class="caret"></span></div>
+  <div data-click-parent=".searchbox" class="btn"><span class="icon-search"></span></div>
 
-  <ul class="dropdown-menu" data-hover-parent=".searchbox">
+  <ul class="dropdown-menu">
     <li class="dropdown-header">
   <input type="text" size="20"
         class="form-control" name="query" id="query"

--- a/jspwiki-war/src/main/webapp/templates/haddock/UserBox.jsp
+++ b/jspwiki-war/src/main/webapp/templates/haddock/UserBox.jsp
@@ -33,9 +33,9 @@
 
 <div class="cage pull-right userbox user-${loginstatus}">
 
-  <div class="btn"><span class="icon-user"></span><span class="caret"></span></div>
+  <div data-click-parent=".userbox" class="btn"><span class="icon-user"></span></div>
 
-  <ul class="dropdown-menu pull-right" data-hover-parent=".userbox">
+  <ul class="dropdown-menu pull-right">
 
     <li>
       <wiki:UserCheck status="anonymous">


### PR DESCRIPTION
Made header buttons clickable instead of hoverable. This change should result in increased usability since the opening boxes frequently would have been closed involuntarily if user's mouse movement was not precise enough after hovering over the buttons. Removed the carets for consistency reasons as they indicate a hoverable target.