### PR TITLE
JSPWIKI-1073 Upgrade the jspwiki-portable build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target
 .classpath
 .project
 nb-configuration.xml
+**/*.iml
+.idea

--- a/jspwiki-portable/build.xml
+++ b/jspwiki-portable/build.xml
@@ -148,11 +148,11 @@
         <singleInstance mutexName="org.apache.jspwiki.jspwiki-portable" />
         <jre minVersion="1.6.0" />
         <versionInfo
-          fileVersion="2.10.5.0"
+          fileVersion="${jspwiki.woas.version}"
           txtFileVersion="JSPWiki ${jspwiki.woas.version}"
           fileDescription="WikiOnAStick"
           copyright="Apache Software Licence 2.0"
-          productVersion="2.10.5.0"
+          productVersion="${jspwiki.woas.version}"
           txtProductVersion="JSPWiki ${jspwiki.woas.version}"
           productName="WikiOnAStick"
           companyName="Apache Software Foundation"

--- a/jspwiki-portable/readme.md
+++ b/jspwiki-portable/readme.md
@@ -1,30 +1,64 @@
-<!--
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
+```
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+   http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
--->
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+```
 
 # 1. Introduction
 
-This project builds a ready-to-use JSP Wiki distribution
+## 1.1 What Is Inside?
 
-* Based on Tomcat 7.0.84 as servlet engine
+This project builds a ready-to-use JSP Wiki distribution for your personal note taking
+
+* Based on embedded Tomcat servlet engine with minimal memory foot-print 
 * Using HTTP port 9627 to avoid conflicts with existing servers running on port 80 and/or 8080
+* Provides native launchers for Windows and Mac OS X (in addition to batch file and shell script)
+* Can be run from an USB stick (`Wiki On A Stick`) or be installed on your PC
 
-# 2. Creating The Native Launchers
+## 1.2 Pre-Configured Wikis
+
+The installation provided two pre-configured JSPWikis
+
+### 1.2.1 Personal Wiki
+
+This configuration makes the following assumptions
+
+* You are the one and only user of JSPWiki
+* You don't need to authenticate for working with JSPWiki
+* Using *BasicSearchProvider* reg-exp grepping
+* No page versioning
+* Registered users with admin rights
+    * "user", "user" 
+* Works nicely with Dropbox as document storage
+
+### 1.2.2 Department Wiki
+
+This configuration makes the following assumptions
+
+* A group of mostly trust-worthy people are using the wiki
+* Anonymous users have with read-only access
+* Using *VersioningFileProvider*
+* *LuceneSearchProvider* only picks up changes through JSPWiki
+* Registered users with read/write access
+    * "admin", "lEtMeIn"
+    * "user", "user" 
+
+# 2. Internals
+
+## 2.1 Creating The Native Launchers
 
 The native launchers are under version control and can be re-created manually. In other words there are not automatically build because
 
@@ -32,7 +66,7 @@ The native launchers are under version control and can be re-created manually. I
 * Downloading all the stuff is time-consuming and would slow the build for everyone
 * There should be some manual testing before promoting the native launchers
 
-## 2.1 Creating The Windows Launcher
+### 2.1.1 Creating The Windows Launcher
 
 Run the following commands
 
@@ -62,7 +96,7 @@ The generated "woas.exe" can be copied manually to *jspwiki-portable/src/overlay
 
 note: on windows platforms, use `ant woas:download-launch4j-for-win woas:create-windows-app` to create the launcher.
 
-## 2.2 Creating The Mac OS X Launcher
+### 2.1.2 Creating The Mac OS X Launcher
 
 Run the following commands
 
@@ -87,49 +121,14 @@ The generated "woas.app" can be copied manually to *jspwiki-portable/src/overlay
 
 note: on windows platforms, use `ant woas:download-appbundler-for-mac woas:download-launch4j-for-mac woas:create-mac-app`
 
-# 3. Current State
+## 2.2. Current State
 
-## 3.1 Mac OS X
+### 2.2.1 Mac OS X
 
-* The Mac OS X [JarBundler](http://informagen.com/JarBundler/index.html) 2.2.0 is used to build a native Mac OS X app but it depends on having the Apple JDK installed
 * Supporting a modern Oracle JDK is done using the [Oracle's AppBundler Task](http://docs.oracle.com/javase/7/docs/technotes/guides/jweb/packagingAppsForMac.html)
+* When executing `woas.app` we get a dock icon bouncing for some time so there is something slightly wrong with the MacOS X integration
+* When executing `woas.app` JSPWiki does not pick up the installation directory but accesses your `~/temp` and `~.log`
 
-## 3.2 Jetty vesus Tomcat
+### 2.2.2 Jetty vesus Tomcat
 
 Over the time Jetty's memory foot-print become larger and larger so I moved back to an embedded Tomcat
-
-# 2. Available Maven Commands
-
-```
-mvn clean package
-```
-
-# 3. The Pre-configured Wikis
-
-## 3.1 Personal Wiki
-
-This configuration makes the following assumptions
-
-* You are the one and only user of JSPWiki
-* You don't need to authenticate for working with JSPWiki
-* Using *BasicSearchProvider* reg-exp grepping
-* No page versioning
-* Registered users with admin rights
-    * "user", "user" 
-
-# 3.2 Department Public Wiki
-
-This configuration makes the following assumptions
-
-* A group of mostly trust-worthy people are using the wiki
-* Anonymous users have with read-only access
-* Using *VersioningFileProvider*
-* *LuceneSearchProvider* only picks up changes through JSPWiki
-* Registered users with read/write access
-    * "admin", "lEtMeIn"
-    * "user", "user" 
-
-
-
-
-

--- a/jspwiki-portable/src/overlay/woas/webapps/department/WEB-INF/classes/jspwiki-custom.properties
+++ b/jspwiki-portable/src/overlay/woas/webapps/department/WEB-INF/classes/jspwiki-custom.properties
@@ -30,6 +30,7 @@ jspwiki.attachment.maxsize=4000000
 jspwiki.breakTitleWithSpaces=true
 jspwiki.searchProvider=LuceneSearchProvider
 jspwiki.security=jaas
+jspwiki.templateDir=haddock
 jspwiki.usePageCache=true
 
 # jspwiki.xmlGroupDatabaseFile=/usr/local/tomcat/lib/groupdatabase.xml

--- a/jspwiki-portable/src/overlay/woas/webapps/personal/WEB-INF/classes/jspwiki-custom.properties
+++ b/jspwiki-portable/src/overlay/woas/webapps/personal/WEB-INF/classes/jspwiki-custom.properties
@@ -30,7 +30,9 @@ jspwiki.breakTitleWithSpaces=true
 jspwiki.pageProvider=FileSystemProvider
 jspwiki.searchProvider=BasicSearchProvider
 jspwiki.security=jaas
+jspwiki.templateDir=haddock
 jspwiki.usePageCache=true
+
 # jspwiki.xmlGroupDatabaseFile=/usr/local/tomcat/lib/groupdatabase.xml
 # jspwiki.xmlUserDatabaseFile=/usr/local/tomcat/lib/userdatabase.xml
 


### PR DESCRIPTION
- Enabled Haddock templates for the two preconfigured wikis
- Improved the `readme.md`
- Impoved the `.gitignore` to handle IntelliJ project files