### PR TITLE
DOCTYPE and HTML lang="en" attribute addition

### DIFF
--- a/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/AclJanneEdit.html
+++ b/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/AclJanneEdit.html
@@ -18,7 +18,7 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<html lang="en">
 <head>
   <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type">
   <title>JSPWiki Test Acl Janne Edit</title>

--- a/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/AclJanneEditAllView.html
+++ b/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/AclJanneEditAllView.html
@@ -18,7 +18,7 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<html lang="en">
 <head>
   <meta content="text/html; charset=ISO-8859-1"
  http-equiv="content-type">

--- a/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/AnonymousCreateGroup.html
+++ b/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/AnonymousCreateGroup.html
@@ -18,7 +18,7 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<html lang="en">
 <head>
   <meta content="text/html; charset=ISO-8859-1"
  http-equiv="content-type">

--- a/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/AnonymousView.html
+++ b/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/AnonymousView.html
@@ -18,7 +18,7 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<html lang="en">
 <head>
   <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type">
   <title>JSPWiki Test Anonymous View</title>

--- a/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/AnonymousViewImage.html
+++ b/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/AnonymousViewImage.html
@@ -18,7 +18,7 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<html lang="en">
 <head>
   <meta content="text/html; charset=ISO-8859-1"
  http-equiv="content-type">

--- a/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/AssertedName.html
+++ b/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/AssertedName.html
@@ -18,7 +18,7 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<html lang="en">
 <head>
   <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type">
   <title>JSPWiki Test Asserted Name</title>

--- a/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/AssertedPermissions.html
+++ b/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/AssertedPermissions.html
@@ -18,7 +18,7 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<html lang="en">
 <head>
   <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type">
   <title>JSPWiki Test Asserted Permissions</title>

--- a/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/CreateGroupFullName.html
+++ b/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/CreateGroupFullName.html
@@ -18,7 +18,7 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<html lang="en">
 <head>
   <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type">
   <title>JSPWiki Test Create Group Full Name</title>

--- a/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/CreateGroupLoginName.html
+++ b/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/CreateGroupLoginName.html
@@ -18,7 +18,7 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<html lang="en">
 <head>
   <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type">
   <title>JSPWiki Test Create Group Login Name</title>

--- a/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/CreateGroupWikiName.html
+++ b/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/CreateGroupWikiName.html
@@ -18,7 +18,7 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<html lang="en">
 <head>
   <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type">
   <title>JSPWiki Test Create Group WikiName</title>

--- a/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/CreatePage.html
+++ b/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/CreatePage.html
@@ -18,7 +18,7 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<html lang="en">
 <head>
   <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type">
   <title>JSPWiki Test Create Page</title>

--- a/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/DeletePage.html
+++ b/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/DeletePage.html
@@ -18,7 +18,7 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<html lang="en">
 <head>
   <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type">
   <title>JSPWiki Test Delete Page</title>

--- a/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/DeletePageNonAdmin.html
+++ b/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/DeletePageNonAdmin.html
@@ -18,7 +18,7 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<html lang="en">
 <head>
   <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type">
   <title>JSPWiki Test Delete Page</title>

--- a/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/Login.html
+++ b/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/Login.html
@@ -18,7 +18,7 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<html lang="en">
 <head>
   <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type">
   <title>JSPWiki Test Login</title>

--- a/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/Logout.html
+++ b/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/Logout.html
@@ -18,7 +18,7 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<html lang="en">
 <head>
   <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type">
   <title>JSPWiki Test Logout</title>

--- a/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/RedirectAfterLogin.html
+++ b/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/RedirectAfterLogin.html
@@ -18,7 +18,7 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<html lang="en">
 <head>
   <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type">
   <title>JSPWiki Test Redirect Page After Login</title>

--- a/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/RenamePage.html
+++ b/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/RenamePage.html
@@ -18,7 +18,7 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<html lang="en">
 <head>
   <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type">
   <title>JSPWiki Test Rename Page</title>

--- a/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/RenameProfile.html
+++ b/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/RenameProfile.html
@@ -18,7 +18,7 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<html lang="en">
 <head>
   <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type">
   <title>JSPWiki Test Rename Profile</title>

--- a/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/TestSuite.html
+++ b/jspwiki-it-tests/jspwiki-selenide-tests/src/test/resources/selenium/TestSuite.html
@@ -18,7 +18,7 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+<html lang="en">
 <head>
 <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type">
 <title>Test Suite</title>

--- a/jspwiki-main/src/main/java/org/apache/wiki/ui/WikiServletFilter.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/ui/WikiServletFilter.java
@@ -114,7 +114,7 @@ public class WikiServletFilter implements Filter
         if( m_engine == null )
         {
             PrintWriter out = response.getWriter();
-            out.print("<html><head><title>Fatal problem with JSPWiki</title></head>");
+            out.print("<!DOCTYPE html><html lang=\"en\"><head><title>Fatal problem with JSPWiki</title></head>");
             out.print("<body>");
             out.print("<h1>JSPWiki has not been started</h1>");
             out.print("<p>JSPWiki is not running.  This is probably due to a configuration error in your jspwiki.properties file, ");

--- a/jspwiki-war/src/main/webapp/admin/Admin.jsp
+++ b/jspwiki-war/src/main/webapp/admin/Admin.jsp
@@ -44,7 +44,8 @@
     if( !TextUtil.isPositive(wiki.getWikiProperties().getProperty("jspwiki-x.adminui.enable")) )
     {
         %>
-        <html>
+        <!DOCTYPE html>
+        <html lang="en">
         <head>
           <base href="../"/>
           <link rel="stylesheet" media="screen, projection" type="text/css" href="<wiki:Link format="url" templatefile="jspwiki.css"/>"/>

--- a/jspwiki-war/src/main/webapp/admin/SecurityConfig.jsp
+++ b/jspwiki-war/src/main/webapp/admin/SecurityConfig.jsp
@@ -47,7 +47,8 @@
   if( !TextUtil.isPositive(wiki.getWikiProperties().getProperty("jspwiki-x.securityconfig.enable")) )
   {
       %>
-      <html>
+      <!DOCTYPE html>
+      <html lang="en">
       <head>
         <base href="../"/>
         <link rel="stylesheet" media="screen, projection" type="text/css" href="<wiki:Link format="url" templatefile="jspwiki.css"/>"/>
@@ -74,7 +75,7 @@
 %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
   <title>JSPWiki Security Configuration Verifier</title>
   <base href="../"/>

--- a/jspwiki-war/src/main/webapp/error/Forbidden.html
+++ b/jspwiki-war/src/main/webapp/error/Forbidden.html
@@ -16,8 +16,8 @@
     specific language governing permissions and limitations
     under the License.
 -->
-
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <style>
     body { margin: 3em auto; width:50%; }
     h3 {

--- a/jspwiki-war/src/main/webapp/templates/210/admin/AdminTemplate.jsp
+++ b/jspwiki-war/src/main/webapp/templates/210/admin/AdminTemplate.jsp
@@ -24,7 +24,8 @@
 <%@ page import="org.apache.wiki.ui.admin.*" %>
 <%@ page errorPage="/Error.jsp" %>
 <%@ taglib uri="http://jspwiki.apache.org/tags" prefix="wiki" %>
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
 <title>JSPWiki administration</title>
   <wiki:Include page="commonheader.jsp"/>

--- a/jspwiki-war/src/main/webapp/templates/default/admin/AdminTemplate.jsp
+++ b/jspwiki-war/src/main/webapp/templates/default/admin/AdminTemplate.jsp
@@ -24,7 +24,8 @@
 <%@ page import="org.apache.wiki.ui.admin.*" %>
 <%@ page errorPage="/Error.jsp" %>
 <%@ taglib uri="http://jspwiki.apache.org/tags" prefix="wiki" %>
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
 <title>JSPWiki administration</title>
   <wiki:Include page="commonheader.jsp"/>


### PR DESCRIPTION
No functional change as this is primarily an accessibility enhancement for screen reader software such as JAWS.   DOCTYPEs added to improve validation.