### PR TITLE
JSPWIKI-1148 - Avoid File Stream

### DIFF
--- a/jspwiki-api/src/main/java/org/apache/wiki/api/core/Engine.java
+++ b/jspwiki-api/src/main/java/org/apache/wiki/api/core/Engine.java
@@ -26,13 +26,13 @@ import org.apache.wiki.util.TextUtil;
 import javax.servlet.ServletContext;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -269,7 +269,7 @@ public interface Engine {
             LogManager.getLogger( Engine.class ).info( "looking for /" + name + " on classpath" );
             //  create a tmp file of the policy loaded as an InputStream and return the URL to it
             try( final InputStream is = Engine.class.getResourceAsStream( "/" + name );
-                    final OutputStream os = new FileOutputStream( tmpFile ) ) {
+                final OutputStream os = Files.newOutputStream( tmpFile.toPath() ) ) {
                 if( is == null ) {
                     throw new FileNotFoundException( name + " not found" );
                 }

--- a/jspwiki-main/src/main/java/org/apache/wiki/attachment/AttachmentManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/attachment/AttachmentManager.java
@@ -29,9 +29,9 @@ import org.apache.wiki.api.providers.AttachmentProvider;
 import org.apache.wiki.api.providers.WikiProvider;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.List;
 
@@ -221,7 +221,7 @@ public interface AttachmentManager {
      *  @throws ProviderException If something else went wrong.
      */
     default void storeAttachment( final Attachment att, final File source ) throws IOException, ProviderException {
-        try( final FileInputStream in = new FileInputStream( source ) ) {
+        try( final InputStream in = Files.newInputStream( source.toPath() ) ) {
             storeAttachment( att, in );
         }
     }

--- a/jspwiki-main/src/main/java/org/apache/wiki/auth/authorize/XMLGroupDatabase.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/auth/authorize/XMLGroupDatabase.java
@@ -37,10 +37,10 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.security.Principal;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -345,7 +345,7 @@ public class XMLGroupDatabase implements GroupDatabase {
         }
 
         final File newFile = new File( m_file.getAbsolutePath() + ".new" );
-        try( final BufferedWriter io = new BufferedWriter( new OutputStreamWriter( new FileOutputStream( newFile ), StandardCharsets.UTF_8 ) ) ) {
+        try( final BufferedWriter io = new BufferedWriter( new OutputStreamWriter( Files.newOutputStream( newFile.toPath() ), StandardCharsets.UTF_8 ) ) ) {
             // Write the file header and document root
             io.write( "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" );
             io.write( "<groups>\n" );

--- a/jspwiki-main/src/main/java/org/apache/wiki/auth/login/CookieAuthenticationLoginModule.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/auth/login/CookieAuthenticationLoginModule.java
@@ -35,8 +35,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
@@ -44,6 +42,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.UUID;
 
 
@@ -124,7 +123,7 @@ public class CookieAuthenticationLoginModule extends AbstractLoginModule {
 
                 if( cookieFile != null && cookieFile.exists() && cookieFile.canRead() ) {
 
-                    try( final Reader in = new BufferedReader( new InputStreamReader( new FileInputStream( cookieFile ), StandardCharsets.UTF_8 ) ) ) {
+                    try( final Reader in = new BufferedReader( new InputStreamReader(Files.newInputStream( cookieFile.toPath() ), StandardCharsets.UTF_8 ) ) ) {
                         final String username = FileUtil.readContents( in );
 
                         if( log.isDebugEnabled() ) {
@@ -225,7 +224,7 @@ public class CookieAuthenticationLoginModule extends AbstractLoginModule {
         final File cf = getCookieFile( engine, uid.toString() );
         if( cf != null ) {
             //  Write the cookie content to the cookie store file.
-            try( final Writer out = new BufferedWriter( new OutputStreamWriter( new FileOutputStream( cf ), StandardCharsets.UTF_8 ) ) ) {
+            try( final Writer out = new BufferedWriter( new OutputStreamWriter( Files.newOutputStream( cf.toPath() ), StandardCharsets.UTF_8 ) ) ) {
                 FileUtil.copyContents( new StringReader( username ), out );
 
                 if( log.isDebugEnabled() ) {

--- a/jspwiki-main/src/main/java/org/apache/wiki/auth/user/XMLUserDatabase.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/auth/user/XMLUserDatabase.java
@@ -38,11 +38,11 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.security.Principal;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -233,7 +233,7 @@ public class XMLUserDatabase extends AbstractUserDatabase {
         }
 
         final File newFile = new File( c_file.getAbsolutePath() + ".new" );
-        try( final BufferedWriter io = new BufferedWriter( new OutputStreamWriter( new FileOutputStream( newFile ), StandardCharsets.UTF_8 ) ) ) {
+        try( final BufferedWriter io = new BufferedWriter( new OutputStreamWriter( Files.newOutputStream( newFile.toPath() ), StandardCharsets.UTF_8 ) ) ) {
 
             // Write the file header and document root
             io.write( "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" );

--- a/jspwiki-main/src/main/java/org/apache/wiki/filters/DefaultFilterManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/filters/DefaultFilterManager.java
@@ -35,9 +35,9 @@ import org.apache.wiki.util.XmlUtil;
 import org.jdom2.Element;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -189,7 +189,7 @@ public class DefaultFilterManager extends BaseModuleManager implements FilterMan
 
             if( (xmlStream == null) && (xmlFile != null) ) {
                 log.debug("Attempting to load property file "+xmlFile);
-                xmlStream = new FileInputStream( new File(xmlFile) );
+                xmlStream = Files.newInputStream( new File(xmlFile).toPath() );
             }
 
             if( xmlStream == null ) {

--- a/jspwiki-main/src/main/java/org/apache/wiki/plugin/PageViewPlugin.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/plugin/PageViewPlugin.java
@@ -46,11 +46,10 @@ import org.apache.wiki.render.RenderingManager;
 import org.apache.wiki.util.TextUtil;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.Comparator;
@@ -511,7 +510,7 @@ public class PageViewPlugin extends AbstractReferralPlugin implements Plugin, In
             if( m_counters != null && m_storage != null ) {
                 log.info( "Loading counters." );
                 synchronized( this ) {
-                    try( final InputStream fis = new FileInputStream( new File( m_workDir, COUNTER_PAGE ) ) ) {
+                    try( final InputStream fis = Files.newInputStream( new File( m_workDir, COUNTER_PAGE ).toPath() ) ) {
                         m_storage.load( fis );
                     } catch( final IOException ioe ) {
                         log.error( "Can't load page counter store: " + ioe.getMessage() + " , will create a new one!" );
@@ -535,7 +534,7 @@ public class PageViewPlugin extends AbstractReferralPlugin implements Plugin, In
                 log.info( "Storing " + m_counters.size() + " counter values." );
                 synchronized( this ) {
                     // Write out the collection of counters
-                    try( final OutputStream fos = new FileOutputStream( new File( m_workDir, COUNTER_PAGE ) ) ) {
+                    try( final OutputStream fos = Files.newOutputStream( new File( m_workDir, COUNTER_PAGE ).toPath() ) ) {
                         m_storage.store( fos, "\n# The number of times each page has been viewed.\n# Do not modify.\n" );
                         fos.flush();
 

--- a/jspwiki-main/src/main/java/org/apache/wiki/providers/AbstractFileProvider.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/providers/AbstractFileProvider.java
@@ -36,15 +36,14 @@ import org.apache.wiki.util.FileUtil;
 import org.apache.wiki.util.TextUtil;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -248,7 +247,7 @@ public abstract class AbstractFileProvider implements PageProvider {
         final File pagedata = findPage( page );
         if( pagedata.exists() ) {
             if( pagedata.canRead() ) {
-                try( final InputStream in = new FileInputStream( pagedata ) ) {
+                try( final InputStream in = Files.newInputStream( pagedata.toPath() ) ) {
                     result = FileUtil.readContents( in, m_encoding );
                 } catch( final IOException e ) {
                     log.error( "Failed to read", e );
@@ -270,7 +269,7 @@ public abstract class AbstractFileProvider implements PageProvider {
     @Override
     public void putPageText( final Page page, final String text ) throws ProviderException {
         final File file = findPage( page.getName() );
-        try( final PrintWriter out = new PrintWriter( new OutputStreamWriter( new FileOutputStream( file ), m_encoding ) ) ) {
+        try( final PrintWriter out = new PrintWriter( new OutputStreamWriter( Files.newOutputStream( file.toPath() ), m_encoding ) ) ) {
             out.print( text );
         } catch( final IOException e ) {
             log.error( "Saving failed", e );
@@ -348,7 +347,7 @@ public abstract class AbstractFileProvider implements PageProvider {
                 final String filename = wikipage.getName();
                 final int cutpoint = filename.lastIndexOf( FILE_EXT );
                 final String wikiname = unmangleName( filename.substring( 0, cutpoint ) );
-                try( final FileInputStream input = new FileInputStream( wikipage ) ) {
+                try( final InputStream input = Files.newInputStream( wikipage.toPath() ) ) {
                     final String pagetext = FileUtil.readContents( input, m_encoding );
                     final SearchResult comparison = matcher.matchPageContent( wikiname, pagetext );
                     if( comparison != null ) {

--- a/jspwiki-main/src/main/java/org/apache/wiki/providers/BasicAttachmentProvider.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/providers/BasicAttachmentProvider.java
@@ -34,13 +34,12 @@ import org.apache.wiki.util.FileUtil;
 import org.apache.wiki.util.TextUtil;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -242,7 +241,7 @@ public class BasicAttachmentProvider implements AttachmentProvider {
     private void putPageProperties( final Attachment att, final Properties properties ) throws IOException, ProviderException {
         final File attDir = findAttachmentDir( att );
         final File propertyFile = new File( attDir, PROPERTY_FILE );
-        try( final OutputStream out = new FileOutputStream( propertyFile ) ) {
+        try( final OutputStream out = Files.newOutputStream( propertyFile.toPath() ) ) {
             properties.store( out, " JSPWiki page properties for " + att.getName() + ". DO NOT MODIFY!" );
         }
     }
@@ -254,7 +253,7 @@ public class BasicAttachmentProvider implements AttachmentProvider {
         final Properties props = new Properties();
         final File propertyFile = new File( findAttachmentDir(att), PROPERTY_FILE );
         if( propertyFile.exists() ) {
-            try( final InputStream in = new FileInputStream( propertyFile ) ) {
+            try( final InputStream in = Files.newInputStream( propertyFile.toPath() ) ) {
                 props.load( in );
             }
         }
@@ -276,7 +275,7 @@ public class BasicAttachmentProvider implements AttachmentProvider {
         final int versionNumber = latestVersion + 1;
 
         final File newfile = new File( attDir, versionNumber + "." + getFileExtension( att.getFileName() ) );
-        try( final OutputStream out = new FileOutputStream( newfile ) ) {
+        try( final OutputStream out = Files.newOutputStream( newfile.toPath() ) ) {
             log.info( "Uploading attachment " + att.getFileName() + " to page " + att.getParentName() );
             log.info( "Saving attachment contents to " + newfile.getAbsolutePath() );
             FileUtil.copyContents( data, out );
@@ -341,7 +340,7 @@ public class BasicAttachmentProvider implements AttachmentProvider {
         final File attDir = findAttachmentDir( att );
         try {
             final File f = findFile( attDir, att );
-            return new FileInputStream( f );
+            return Files.newInputStream( f.toPath() );
         } catch( final FileNotFoundException e ) {
             log.error( "File not found: " + e.getMessage() );
             throw new ProviderException( "No such page was found." );

--- a/jspwiki-main/src/main/java/org/apache/wiki/providers/FileSystemProvider.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/providers/FileSystemProvider.java
@@ -24,11 +24,10 @@ import org.apache.wiki.api.core.Page;
 import org.apache.wiki.api.exceptions.ProviderException;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.Properties;
 
 /**
@@ -84,7 +83,7 @@ public class FileSystemProvider extends AbstractFileProvider {
         getCustomProperties( page, props );
 
         final File file = new File( getPageDirectory(), mangleName( page.getName() ) + PROP_EXT );
-        try( final OutputStream out = new FileOutputStream( file ) ) {
+        try( final OutputStream out = Files.newOutputStream( file.toPath() ) ) {
             props.store( out, "JSPWiki page properties for page "+page.getName() );
         }
     }
@@ -95,7 +94,7 @@ public class FileSystemProvider extends AbstractFileProvider {
     private void getPageProperties( final Page page ) throws IOException {
         final File file = new File( getPageDirectory(), mangleName( page.getName() ) + PROP_EXT );
         if( file.exists() ) {
-            try( final InputStream in = new FileInputStream( file ) ) {
+            try( final InputStream in = Files.newInputStream( file.toPath() ) ) {
                 final Properties  props = new Properties();
                 props.load( in );
                 page.setAuthor( props.getProperty( Page.AUTHOR ) );

--- a/jspwiki-main/src/main/java/org/apache/wiki/providers/VersioningFileProvider.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/providers/VersioningFileProvider.java
@@ -33,11 +33,10 @@ import org.apache.wiki.util.FileUtil;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -214,7 +213,7 @@ public class VersioningFileProvider extends AbstractFileProvider {
                 return cp.m_props;
             }
 
-            try( final InputStream in = new BufferedInputStream(new FileInputStream( propertyFile ) ) ) {
+            try( final InputStream in = new BufferedInputStream( Files.newInputStream( propertyFile.toPath() ) ) ) {
                 final Properties props = new Properties();
                 props.load( in );
                 cp = new CachedProperties( page, props, lastModified );
@@ -233,7 +232,7 @@ public class VersioningFileProvider extends AbstractFileProvider {
      */
     private void putPageProperties( final String page, final Properties properties ) throws IOException {
         final File propertyFile = new File( findOldPageDir(page), PROPERTYFILE );
-        try( final OutputStream out = new FileOutputStream( propertyFile ) ) {
+        try( final OutputStream out = Files.newOutputStream( propertyFile.toPath() ) ) {
             properties.store( out, " JSPWiki page properties for "+page+". DO NOT MODIFY!" );
         }
 
@@ -293,7 +292,7 @@ public class VersioningFileProvider extends AbstractFileProvider {
         String result = null;
         if( pagedata.exists() ) {
             if( pagedata.canRead() ) {
-                try( final InputStream in = new FileInputStream( pagedata ) ) {
+                try( final InputStream in = Files.newInputStream( pagedata.toPath() ) ) {
                     result = FileUtil.readContents( in, m_encoding );
                 } catch( final IOException e ) {
                     log.error("Failed to read", e);
@@ -347,8 +346,8 @@ public class VersioningFileProvider extends AbstractFileProvider {
 
             if( oldFile != null && oldFile.exists() ) {
                 final File pageFile = new File( pageDir, versionNumber + FILE_EXT );
-                try( final InputStream in = new BufferedInputStream( new FileInputStream( oldFile ) );
-                     final OutputStream out = new BufferedOutputStream( new FileOutputStream( pageFile ) ) ) {
+                try( final InputStream in = new BufferedInputStream( Files.newInputStream( oldFile.toPath() ) );
+                     final OutputStream out = new BufferedOutputStream( Files.newOutputStream( pageFile.toPath() ) ) ) {
                     FileUtil.copyContents( in, out );
 
                     // We need also to set the date, since we rely on this.
@@ -518,7 +517,7 @@ public class VersioningFileProvider extends AbstractFileProvider {
                 return cp.m_props;
             }
 
-            try( final InputStream in = new BufferedInputStream( new FileInputStream( propertyFile ) ) ) {
+            try( final InputStream in = new BufferedInputStream( Files.newInputStream( propertyFile.toPath() ) ) ) {
                 final Properties props = new Properties();
                 props.load( in );
 
@@ -600,8 +599,8 @@ public class VersioningFileProvider extends AbstractFileProvider {
             final File pageDir = findOldPageDir( page );
             final File previousFile = new File( pageDir, latest + FILE_EXT );
             final File pageFile = findPage(page);
-            try( final InputStream in = new BufferedInputStream( new FileInputStream( previousFile ) );
-                 final OutputStream out = new BufferedOutputStream( new FileOutputStream( pageFile ) ) ) {
+            try( final InputStream in = new BufferedInputStream( Files.newInputStream( previousFile.toPath() ) );
+                 final OutputStream out = new BufferedOutputStream( Files.newOutputStream( pageFile.toPath() ) ) ) {
                 if( previousFile.exists() ) {
                     FileUtil.copyContents( in, out );
                     // We need also to set the date, since we rely on this.

--- a/jspwiki-main/src/main/java/org/apache/wiki/references/DefaultReferenceManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/references/DefaultReferenceManager.java
@@ -42,6 +42,7 @@ import org.apache.wiki.util.TextUtil;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
@@ -235,7 +236,7 @@ public class DefaultReferenceManager extends BasePageFilter implements Reference
         final long saved;
 
         final File f = new File( m_engine.getWorkDir(), SERIALIZATION_FILE );
-        try( final ObjectInputStream in = new ObjectInputStream( new BufferedInputStream( new FileInputStream( f ) ) ) ) {
+        try( final ObjectInputStream in = new ObjectInputStream( new BufferedInputStream( Files.newInputStream( f.toPath() ) ) ) ) {
             final StopWatch sw = new StopWatch();
             sw.start();
 
@@ -264,7 +265,7 @@ public class DefaultReferenceManager extends BasePageFilter implements Reference
      */
     private synchronized void serializeToDisk() {
         final File f = new File( m_engine.getWorkDir(), SERIALIZATION_FILE );
-        try( final ObjectOutputStream out = new ObjectOutputStream( new BufferedOutputStream( new FileOutputStream( f ) ) ) ) {
+        try( final ObjectOutputStream out = new ObjectOutputStream( new BufferedOutputStream( Files.newOutputStream( f.toPath() ) ) ) ) {
             final StopWatch sw = new StopWatch();
             sw.start();
 
@@ -311,7 +312,7 @@ public class DefaultReferenceManager extends BasePageFilter implements Reference
                 return 0L;
             }
 
-            try( final ObjectInputStream in = new ObjectInputStream( new BufferedInputStream( new FileInputStream( f ) ) ) ) {
+            try( final ObjectInputStream in = new ObjectInputStream( new BufferedInputStream( Files.newInputStream( f.toPath() ) ) ) ) {
                 final StopWatch sw = new StopWatch();
                 sw.start();
                 log.debug( "Deserializing attributes for " + p.getName() );
@@ -363,7 +364,7 @@ public class DefaultReferenceManager extends BasePageFilter implements Reference
             //  Create a digest for the name
             f = new File( f, hashName );
 
-            try( final ObjectOutputStream out =  new ObjectOutputStream( new BufferedOutputStream( new FileOutputStream( f ) ) ) ) {
+            try( final ObjectOutputStream out =  new ObjectOutputStream( new BufferedOutputStream( Files.newOutputStream( f.toPath() ) ) ) ) {
                 // new Set to avoid concurrency issues
                 final Set< Map.Entry < String, Object > > entries = new HashSet<>( p.getAttributes().entrySet() );
 

--- a/jspwiki-main/src/main/java/org/apache/wiki/rss/RSSThread.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/rss/RSSThread.java
@@ -27,13 +27,13 @@ import org.apache.wiki.util.FileUtil;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 
 /**
@@ -88,7 +88,7 @@ public class RSSThread extends WikiBackgroundThread {
 
             // Generate RSS file, output it to default "rss.rdf".
             try( final Reader in  = new StringReader( feed );
-                 final Writer out = new BufferedWriter( new OutputStreamWriter( new FileOutputStream( m_rssFile ), StandardCharsets.UTF_8 ) ) ) {
+                final Writer out = new BufferedWriter( new OutputStreamWriter( Files.newOutputStream( m_rssFile.toPath() ), StandardCharsets.UTF_8 ) ) ) {
                 FileUtil.copyContents( in, out );
             } catch( final IOException e ) {
                 log.error( "Cannot generate RSS feed to " + m_rssFile.getAbsolutePath(), e );

--- a/jspwiki-main/src/main/java/org/apache/wiki/ui/Installer.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/ui/Installer.java
@@ -38,9 +38,9 @@ import org.apache.wiki.util.TextUtil;
 import javax.servlet.ServletConfig;
 import javax.servlet.http.HttpServletRequest;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.text.MessageFormat;
 import java.util.Properties;
 import java.util.ResourceBundle;
@@ -202,7 +202,7 @@ public class Installer {
         final ResourceBundle rb = ResourceBundle.getBundle( InternationalizationManager.CORE_BUNDLE, m_session.getLocale() );
         // Write the file back to disk
         try {
-            try( final OutputStream out = new FileOutputStream( m_propertyFile ) ) {
+            try( final OutputStream out = Files.newOutputStream( m_propertyFile.toPath() ) ) {
                 m_props.store( out, null );
             }
             m_session.addMessage( INSTALL_INFO, MessageFormat.format(rb.getString("install.installer.props.saved"), m_propertyFile) );

--- a/jspwiki-main/src/main/java/org/apache/wiki/workflow/DefaultWorkflowManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/workflow/DefaultWorkflowManager.java
@@ -34,6 +34,7 @@ import org.apache.wiki.event.WorkflowEvent;
 import org.apache.wiki.util.TextUtil;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.security.Principal;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -133,7 +134,7 @@ public class DefaultWorkflowManager implements WorkflowManager {
         long saved = 0L;
         final StopWatch sw = new StopWatch();
         sw.start();
-        try( final ObjectInputStream in = new ObjectInputStream( new BufferedInputStream( new FileInputStream( f ) ) ) ) {
+        try( final ObjectInputStream in = new ObjectInputStream( new BufferedInputStream( Files.newInputStream( f.toPath() ) ) ) ) {
             final long ver = in.readLong();
             if( ver != serialVersionUID ) {
                 LOG.warn( "File format has changed; Unable to recover workflows and decision queue from disk." );
@@ -157,7 +158,7 @@ public class DefaultWorkflowManager implements WorkflowManager {
      *  Serializes workflows and decisionqueue to disk.  The format is private, don't touch it.
      */
     synchronized void serializeToDisk( final File f ) {
-        try( final ObjectOutputStream out = new ObjectOutputStream( new BufferedOutputStream( new FileOutputStream( f ) ) ) ) {
+        try( final ObjectOutputStream out = new ObjectOutputStream( new BufferedOutputStream( Files.newOutputStream( f.toPath() ) ) ) ) {
             final StopWatch sw = new StopWatch();
             sw.start();
 

--- a/jspwiki-util/src/main/java/org/apache/wiki/util/FileUtil.java
+++ b/jspwiki-util/src/main/java/org/apache/wiki/util/FileUtil.java
@@ -42,6 +42,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 /**
  *  Generic utilities related to file and stream handling.
@@ -72,7 +73,7 @@ public final class FileUtil {
     public static File newTmpFile( final String content, final Charset encoding ) throws IOException {
         final File f = File.createTempFile( "jspwiki", null );
         try( final Reader in = new StringReader( content );
-             final Writer out = new OutputStreamWriter( new FileOutputStream( f ), encoding ) ) {
+            final Writer out = new OutputStreamWriter( Files.newOutputStream( f.toPath() ), encoding ) ) {
             copyContents( in, out );
         }
 

--- a/jspwiki-util/src/main/java/org/apache/wiki/util/PropertyReader.java
+++ b/jspwiki-util/src/main/java/org/apache/wiki/util/PropertyReader.java
@@ -24,12 +24,14 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.servlet.ServletContext;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.nio.file.Files;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
 
 
 /**
@@ -171,7 +173,7 @@ public final class PropertyReader {
      * @return inputstream holding the properties file
      * @throws FileNotFoundException properties file not found
      */
-	static InputStream loadCustomPropertiesFile( final ServletContext context, final String propertyFile ) throws FileNotFoundException {
+	static InputStream loadCustomPropertiesFile( final ServletContext context, final String propertyFile ) throws IOException {
         final InputStream propertyStream;
 		if( propertyFile == null ) {
 		    LOG.debug( "No " + PARAM_CUSTOMCONFIG + " defined for this context, looking for custom properties file with default name of: " + CUSTOM_JSPWIKI_CONFIG );
@@ -179,7 +181,7 @@ public final class PropertyReader {
 		    propertyStream =  locateClassPathResource(context, CUSTOM_JSPWIKI_CONFIG);
 		} else {
 		    LOG.debug( PARAM_CUSTOMCONFIG + " defined, using " + propertyFile + " as the custom properties file." );
-		    propertyStream = new FileInputStream( propertyFile );
+            propertyStream = Files.newInputStream( new File(propertyFile).toPath() );
 		}
 		return propertyStream;
 	}


### PR DESCRIPTION
Replace construction of FileInputStream and FileOutputStream objects with Files NIO APIs.
Please note, that the java.nio API does not throw a FileNotFoundException anymore, instead it throws a NoSuchFileException. 
 
https://github.com/apache/jspwiki/blob/master/jspwiki-util/src/main/java/org/apache/wiki/util/PropertyReader.java#L144