### PR TITLE
Bumps log4j to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <jrcs-diff.version>0.4.2</jrcs-diff.version>
     <junit.version>5.8.2</junit.version>
     <log4j.version>1.2.17</log4j.version>
-    <log4j2.version>2.14.1</log4j2.version>
+    <log4j2.version>2.15.0</log4j2.version>
     <lucene.version>8.11.0</lucene.version>
     <mockito.version>4.0.0</mockito.version>
     <nekohtml.version>1.9.22</nekohtml.version>


### PR DESCRIPTION
Fixes log4j RCE by bumping the version of log4j2 to version 2.15.0.  I've shared my findings privately with the security team.