### PR TITLE
Fixing italian locale

### DIFF
--- a/jspwiki-main/src/main/resources/CoreResources_it.properties
+++ b/jspwiki-main/src/main/resources/CoreResources_it.properties
@@ -22,7 +22,7 @@
 # Please, do not forget to use proper HTML entities, so
 #   " = &quot;
 #   ' = &#39;  Note that &apos; is NOT HTML, and does not necessarily work in all browsers.
-# 
+#
 # Provided by L. Gilardoni, Quinary - Feb 2008.
 #
 #  Time/date formatting.  Some plugins might be using some specific formats,
@@ -56,7 +56,7 @@ security.error.blankpassword=La password non pu&ograve; essere vuota
 security.error.passwordnomatch=Le password non corrispondono
 
 security.error.illegalfullname=Il nome completo &quot;{0}&quot; non &grave; ammesso
-security.error.illegalloginname=L'identificativo &quot;{0}&quot; non &grave; ammesso
+security.error.illegalloginname=L''identificativo &quot;{0}&quot; non &grave; ammesso
 
 security.error.cannot.rename = Impossibile rinominare: il nome utente ''{0}'' è già utilizzato.
 security.error.fullname.taken = Qualcuno con il nome ''{0}'' è già registrato.
@@ -78,21 +78,21 @@ rename.identical=Nomi delle pagine identici.  Seleziona "back" sul browser e cam
 rename.exists=La pagina "{0}" esiste gi&agrave;. Seleziona "back" sul browser e cambia il nuovo nome o cancella prima la pagina "{0}".
 rename.unknownerror=Errore sconosciuto: ({0})
 
-# Login.jsp  
+# Login.jsp
 #login.error.capslock=Invalid login (please check your Caps Lock key) #obsolete
-login.error.password=L'identificativo non &egrave; valido.
+login.error.password=L'identificativo non è valido.
 login.error.noaccess=Spiacente, sembra che la risorsa non sia accessibile.
 
 # Lostpassword.jsp
 
 # 0 = login name, 1 = password, 2 = URL, 3 = Application name (as signature)
 # This is text, not HTML.
-lostpwd.newpassword.email=Come richiesto, la nuova password per l'autenticazione di "{0}" &egrave; "{1}" \
+lostpwd.newpassword.email=Come richiesto, la nuova password per l''autenticazione di "{0}" è "{1}" \
                     \n\nPuoi collegarti a: {2}.\n\n-- {3}
 lostpwd.newpassword.subject=Nuova password per {0}
-lostpwd.nouser=Nessun utente o email &#39;{0}&#39; trovato.
+lostpwd.nouser=Nessun utente o email "{0}" trovato.
 lostpwd.nomail=Errore Interno: impossibile inviare la mail!  Vi preghiamo di contattare l'amministratore del sito.
-lostpwd.emailed=Una nuova password &egrave; stata inviata via email all'account registrato.
+lostpwd.emailed=Una nuova password è stata inviata via email all'account registrato.
 
 lostpwd.reset.title=Reset della Password
 lostpwd.reset.unable=Impossibile resettare la password. Tentate di nuovo.
@@ -122,7 +122,7 @@ userprofile.noroles=(nessuno)
 # NewGroup.jsp
 newgroup.exists=Il grouppo {0} esiste gi&agrave;. Prova con un altro nome.
 
-# JSPWikiMarkupParser 
+# JSPWikiMarkupParser
 
 markupparser.error.invalidset = Trovato SET non valido: {0}
 markupparser.error.nointerwikiref = Nessun riferimento InterWiki definito nelle proprietà Wiki chiamato "{0}"!
@@ -152,9 +152,9 @@ install.jsp.intro.p3=Questo sistema di setup &egrave; pensato per chi vuole aver
                      Se volete integrare JSPWiki in un sistema esistente, vi raccomandiamo di modificare il file\
                      <code>jspwiki.properties</code> direttamente.  Potete trovare una configurazione di esempio sotto:\
                      <code>yourwiki/WEB-INF/</code>.
-install.jsp.install.info=Buone notizie: 
-install.jsp.install.warning=Attenzione: 
-install.jsp.install.error=Impossibile salvare la configurazione: 
+install.jsp.install.info=Buone notizie:
+install.jsp.install.warning=Attenzione:
+install.jsp.install.error=Impossibile salvare la configurazione:
 install.jsp.install.msg.rnd.pwd=Siccome non esiste ancora un account di amministrazione, JSPWiki ne ha creato uno, con\
                                 password casuale. Potete cambiare questa password pi&ugrave; tardi. L'identificativo di questo account &grave;\
                                 {0} e la password &egrave;{1}. Per favore, annotate questa informazione e tenetela in un posto \
@@ -162,7 +162,7 @@ install.jsp.install.msg.rnd.pwd=Siccome non esiste ancora un account di amminist
 install.jsp.install.msg.admin.notexists=E' la prima volta che avete eseguito questo installer? Se si, dovete sapere che\
                                         dopo che JSPWiki ha validato e salvato la vostra configurazione la prima volta, avrete\
                                         bisogno dei privilegi di amministratore per accedere ancora a questa pagina. Lo facciamo per evitare \
-                                        che persone non autorizzate possano compiere atti non voluti sul vostro wiki.   
+                                        che persone non autorizzate possano compiere atti non voluti sul vostro wiki.
 
 install.jsp.basics.title=Elementi base
 install.jsp.basics.appname.label=Nome dell' Applicazione
@@ -177,13 +177,13 @@ install.jsp.basics.page.storage.desc=Per default, JSPWiki user&agrave; un Versio
 install.jsp.security.title=Sicurezza
 install.jsp.security.sec.conf.label=Configurazione della Sicurezza
 install.jsp.security.sec.conf.opt1=Sicurezza basata su JAAS e sul container (default)
-install.jsp.security.sec.conf.opt2=Sicurezza basata solo sul Container 
+install.jsp.security.sec.conf.opt2=Sicurezza basata solo sul Container
 install.jsp.security.sec.conf.desc=Per default, JSPWiki gestisce gli accessi alle risorse usando un sistema di sicurezza basato su JAAS. \
                                    Verranno rispettati anche eventuali vincoli di sicurezza impostati sul Container, \
                                    se sono stati abilitati nel file <code>web.xml</code>. Se disabilitate la sicurezza JAAS, \
                                    JSPWiki potrebbe non funzionare come ci si aspetta. Ma in qualche caso questo potrebbe essere voluto, soprattutto se \
                                    state tentando di diagnosticare eventuali problemi.
-install.jsp.security.admaccount.label=Account di Amministratore 
+install.jsp.security.admaccount.label=Account di Amministratore
 install.jsp.security.admaccount.enabled=Abilitato
 install.jsp.security.admaccount.notenabled=Non abilitato
 install.jsp.security.admaccount.enabled.desc=Questo wiki ha un account di amministratore con identificativo <strong>admin</strong> che f&agrave; parte \
@@ -198,7 +198,7 @@ install.jsp.adv.settings.logfile.desc=JSPWiki usa Apache Log4j per il logging.  
 install.jsp.adv.settings.workdir.label=Directory di lavoro
 install.jsp.adv.settings.workdir.desc=Questo &egrave; il posto dove vengono mantenute le caches e altro materiale runtime.
 install.jsp.instr.desc=Dopo che avrete selezionato <em>Configura!</em>, l' installer scriver&agrave; i setting ottenuti in: <code>{0}</code>. \
-                       Verr&agrave; anche creato un account di Amministratore con una password casuale e un corrispondente gruppo Admin. 
+                       Verr&agrave; anche creato un account di Amministratore con una password casuale e un corrispondente gruppo Admin.
 install.jsp.instr.submit=Configura!
 install.jsp.validated.new.props=Ecco il vostro nuovo file  jspwiki.properties
 


### PR DESCRIPTION
I found a problem with many Italian texts that are not interpolated correctly because it uses two different ways to load the texts. Some parts of the Wiki is using an `rb.getStriong('security.error.illegalloginname')` and some parts are using the `MessageFormat.format( rb.getStriong('security.error.illegalloginname') )`, with that is very difficult to fix all sentences that uses apostrophe in Italian.

I fixed some texts to enable the recovery password in Italian.

### How to test

```java
import java.io.*;
import java.text.MessageFormat;

class Simple{
    public static void main(String argsx[]){
	Object[] args = { "myemail@gmail.com" };
	String wrongText = MessageFormat.format("Come richiesto, la nuova password per l'autenticazione di \"{0}\" ", args);
        System.out.println("Message: " + wrongText);
        // result: Message: Come richiesto, la nuova password per lautenticazione di "{0}" 


	String correctText = MessageFormat.format("Come richiesto, la nuova password per l''autenticazione di \"{0}\" ", args);
        System.out.println("Message: " + correctText);
        // result: Message: Come richiesto, la nuova password per l'autenticazione di "myemail@gmail.com"
    }
}
```

### Proposal of implementation
Create a new class to access the texts using the Method Overloading:

```java
class Texts {
  public String getString(String name){
    String text = rb.getString(name);\
    Object[] args = {};
    return MessageFormat.format(text, args);
  }

  public String getString(String name, Object[] args){
    String text = rb.getString(name);
    return MessageFormat.format(text, args);
  }
}
```

Using that will be easier to maintain all texts with accents or symbols in a central method and an easy way to implement functions to render HTML Entities.