### PR TITLE
[JSPWIKI-1172] Set jspwiki.workDir default to servlet context temp directory

### DIFF
--- a/jspwiki-api/src/test/java/org/apache/wiki/api/spi/WikiTest.java
+++ b/jspwiki-api/src/test/java/org/apache/wiki/api/spi/WikiTest.java
@@ -43,7 +43,7 @@ public class WikiTest {
     public void testWikiInit() {
         Mockito.doReturn( sc ).when( conf ).getServletContext();
         final Properties properties = Wiki.init( sc );
-        Assertions.assertEquals( 5, properties.size() );
+        Assertions.assertEquals( 6, properties.size() );
 
         // verify SPIs are initialized and can be invoked
         Assertions.assertNull( Wiki.acls().acl() );

--- a/jspwiki-bootstrap/src/main/java/org/apache/wiki/bootstrap/WikiBootstrapServletContextListener.java
+++ b/jspwiki-bootstrap/src/main/java/org/apache/wiki/bootstrap/WikiBootstrapServletContextListener.java
@@ -27,10 +27,12 @@ import org.apache.logging.log4j.core.config.properties.PropertiesConfigurationFa
 import org.apache.wiki.api.spi.Wiki;
 import org.apache.wiki.util.TextUtil;
 
+import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
@@ -97,5 +99,4 @@ public class WikiBootstrapServletContextListener implements ServletContextListen
     @Override
     public void contextDestroyed( final ServletContextEvent sce ) {
     }
-
 }

--- a/jspwiki-bootstrap/src/test/java/org/apache/wiki/bootstrap/WikiBootstrapServletContextListenerTest.java
+++ b/jspwiki-bootstrap/src/test/java/org/apache/wiki/bootstrap/WikiBootstrapServletContextListenerTest.java
@@ -28,6 +28,8 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import java.util.Properties;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 
 @ExtendWith( MockitoExtension.class )
 public class WikiBootstrapServletContextListenerTest {
@@ -41,7 +43,7 @@ public class WikiBootstrapServletContextListenerTest {
         final WikiBootstrapServletContextListener listener = new WikiBootstrapServletContextListener();
         final Properties properties = listener.initWikiSPIs( sce );
 
-        Assertions.assertEquals( 35, properties.size() );
+        Assertions.assertEquals( 36, properties.size() );
     }
 
     @Test
@@ -62,5 +64,4 @@ public class WikiBootstrapServletContextListenerTest {
         Assertions.assertDoesNotThrow( () -> listener.contextInitialized( sce ) );
         Assertions.assertDoesNotThrow( () -> listener.contextDestroyed( sce ) );
     }
-
 }

--- a/jspwiki-main/src/main/java/org/apache/wiki/WikiEngine.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/WikiEngine.java
@@ -348,9 +348,6 @@ public class WikiEngine implements Engine {
 
     void createAndFindWorkingDirectory( final Properties props ) throws WikiException {
         m_workDir = TextUtil.getStringProperty( props, PROP_WORKDIR, null );
-        if( StringUtils.isBlank( m_workDir ) ) {
-            m_workDir = System.getProperty( "java.io.tmpdir", "." ) +  File.separator + Release.APPNAME + "-" + m_appid;
-        }
 
         final File f = new File( m_workDir );
         try {

--- a/jspwiki-main/src/main/java/org/apache/wiki/ui/Installer.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/ui/Installer.java
@@ -66,7 +66,7 @@ public class Installer {
     public static final String WORK_DIR = Engine.PROP_WORKDIR;
     public static final String ADMIN_GROUP = "Admin";
     public static final String PROPFILENAME = "jspwiki-custom.properties" ;
-    public static final String TMP_DIR = System.getProperty("java.io.tmpdir");
+    public static String TMP_DIR;
     private final Session m_session;
     private final File m_propertyFile;
     private final Properties m_props;
@@ -86,6 +86,7 @@ public class Installer {
         // Stash the request
         m_request = request;
         m_validated = false;
+        TMP_DIR = m_engine.getWikiProperties().getProperty( "jspwiki.workDir" );
     }
     
     /**

--- a/jspwiki-util/pom.xml
+++ b/jspwiki-util/pom.xml
@@ -99,5 +99,12 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>


### PR DESCRIPTION
Description:

This pull request addresses the issue [JSPWIKI-1172](https://issues.apache.org/jira/browse/JSPWIKI-1172) by changing the default value of jspwiki.workDir from java.io.tmpdir to the servlet container's context-specific temp directory, as provided by the "javax.servlet.context.tempdir" context attribute.

Key Changes:

-  A new ServletContextListener, WikiServletContextListener, has been created to manage this setting during context initialization.
-  In case the servlet container does not provide a temporary directory, the system's default temporary directory is used as a fallback.
- This modification aids in avoiding possible problems associated with space limitations in the system's temporary directory, especially on Unix systems where /tmp is often space-limited and sometimes located in a ramdisk.

Testing:

- Unit tests have been added for the new WikiServletContextListener to ensure the directory is set correctly during context initialization, and that an exception is thrown if the directory is not writable.
