### PR TITLE
Constant charset String literal (for example, "UTF-8") can be replaced with the predefined StandardCharsets.UTF_8 code.

### DIFF
--- a/jspwiki-main/src/main/java/org/apache/wiki/parser/CreoleToJSPWikiTranslator.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/parser/CreoleToJSPWikiTranslator.java
@@ -506,7 +506,7 @@ public class CreoleToJSPWikiTranslator
             {
                 final MessageDigest digest = MessageDigest.getInstance("MD5");
                 digest.reset();
-                digest.update(protectedMarkup.getBytes(StandardCharsets.UTF_8.name()));
+                digest.update(protectedMarkup.getBytes(StandardCharsets.UTF_8));
                 final String hash = bytesToHash(digest.digest());
                 matcher.appendReplacement(result, hash);
                 c_protectionMap.put(hash, protectedMarkup);
@@ -515,11 +515,6 @@ public class CreoleToJSPWikiTranslator
             catch (final NoSuchAlgorithmException e)
             {
                 // FIXME: Should log properly
-                e.printStackTrace();
-            }
-            catch (final UnsupportedEncodingException e)
-            {
-                // FIXME: Auto-generated catch block
                 e.printStackTrace();
             }
         }

--- a/jspwiki-main/src/main/java/org/apache/wiki/tags/CookieTag.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/tags/CookieTag.java
@@ -379,16 +379,7 @@ public class CookieTag
      */
     private String encode(final String nvp )
     {
-        String coded = "";
-        try
-        {
-            coded = URLEncoder.encode( nvp, StandardCharsets.UTF_8.name() );
-        }
-        catch( final UnsupportedEncodingException e )
-        {
-            /* never happens */
-            LOG.info( "Failed to encode UTF-8", e );
-        }
+        final String coded = URLEncoder.encode( nvp, StandardCharsets.UTF_8 );
         return coded.replaceAll( "\\+", "%20" );
     }
 
@@ -399,16 +390,8 @@ public class CookieTag
     private String decode(final String envp )
     {
         final String rval;
-        try
-        {
-            rval = URLDecoder.decode( envp , StandardCharsets.UTF_8.name() );
-            return rval;
-        }
-        catch( final UnsupportedEncodingException e )
-        {
-            LOG.error( "Failed to decode cookie", e );
-            return envp;
-        }
+        rval = URLDecoder.decode( envp , StandardCharsets.UTF_8);
+        return rval;
     }
 
     /**

--- a/jspwiki-wysiwyg/src/main/java/org/apache/wiki/htmltowiki/XHtmlToWikiConfig.java
+++ b/jspwiki-wysiwyg/src/main/java/org/apache/wiki/htmltowiki/XHtmlToWikiConfig.java
@@ -186,30 +186,26 @@ public class XHtmlToWikiConfig {
         if( ref == null ) {
             return null;
         }
-        try {
-            ref = URLDecoder.decode( ref, StandardCharsets.UTF_8.name() );
-            ref = ref.trim();
-            if( ref.startsWith( getAttachPage() ) ) {
-                ref = ref.substring( getAttachPage().length() );
-            }
-            if( ref.startsWith( getWikiJspPage() ) ) {
-                ref = ref.substring( getWikiJspPage().length() );
+        ref = URLDecoder.decode( ref, StandardCharsets.UTF_8);
+        ref = ref.trim();
+        if( ref.startsWith( getAttachPage() ) ) {
+            ref = ref.substring( getAttachPage().length() );
+        }
+        if( ref.startsWith( getWikiJspPage() ) ) {
+            ref = ref.substring( getWikiJspPage().length() );
 
-                // Handle links with section anchors.
-                // For example, we need to translate the html string "TargetPage#section-TargetPage-Heading2"
-                // to this wiki string "TargetPage#Heading2".
-                ref = ref.replaceFirst( ".+#section-(.+)-(.+)", "$1#$2" );
+            // Handle links with section anchors.
+            // For example, we need to translate the html string "TargetPage#section-TargetPage-Heading2"
+            // to this wiki string "TargetPage#Heading2".
+            ref = ref.replaceFirst( ".+#section-(.+)-(.+)", "$1#$2" );
+        }
+        if( ref.startsWith( getEditJspPage() ) ) {
+            ref = ref.substring( getEditJspPage().length() );
+        }
+        if( getPageName() != null ) {
+            if( ref.startsWith( getPageName() ) ) {
+                ref = ref.substring( getPageName().length() );
             }
-            if( ref.startsWith( getEditJspPage() ) ) {
-                ref = ref.substring( getEditJspPage().length() );
-            }
-            if( getPageName() != null ) {
-                if( ref.startsWith( getPageName() ) ) {
-                    ref = ref.substring( getPageName().length() );
-                }
-            }
-        } catch ( final UnsupportedEncodingException e ) {
-            // Shouldn't happen...
         }
         return ref;
     }


### PR DESCRIPTION
The code after the fix may work faster, because the charset lookup becomes unnecessary. Also, catching UnsupportedEncodingException may become unnecessary as well. In this case, the catch block will be removed automatically.