### PR TITLE
JSPWIKI-1181 - Fix: Correct URL Generation for Pages with Special Characters

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,7 @@ under the License.
 
 * [JSPWIKI-1167](https://issues.apache.org/jira/browse/JSPWIKI-1167) - prettify: line numbering is wrong with longer lines
     Prettified code lines should not wrap around, to avoid mismatch with line numbering.
+* [JSPWIKI-1181](https://issues.apache.org/jira/browse/JSPWIKI-1167) - Search popup does not handle attachments correctly.
     
 **2023-09-09  Dirk Frederickx (brushed AT apache DOT org)**
 

--- a/jspwiki-api/src/main/java/org/apache/wiki/api/Release.java
+++ b/jspwiki-api/src/main/java/org/apache/wiki/api/Release.java
@@ -69,7 +69,7 @@ public final class Release {
      *  <p>
      *  If the build identifier is empty, it is not added.
      */
-    public static final String     BUILD         = "02";
+    public static final String     BUILD         = "03";
 
     /**
      *  This is the generic version string you should use when printing out the version.  It is of

--- a/jspwiki-war/src/main/scripts/wiki/Wiki.js
+++ b/jspwiki-war/src/main/scripts/wiki/Wiki.js
@@ -528,16 +528,14 @@ var Wiki = {
     },
 
     /*
-    Property: cleanPageName
-        Remove all not-allowed chars from a pagename.
-        Trim all whitespace, allow letters, digits and punctuation chars: ()&+, -=._$
-        Mirror of org.apache.wiki.parser.MarkupParser.cleanPageName()
-    */
-    cleanPageName: function( pagename ){
-
+      Property: cleanPageName
+          Remove all not-allowed chars from a pagename.
+          Trim all whitespace, allow letters, digits and punctuation chars: ()&+, -=._$/ (Note: '/' is now allowed)
+          Mirror of org.apache.wiki.parser.MarkupParser.cleanPageName()
+  */
+    cleanPageName: function(pagename) {
         //\w is short for [A-Z_a-z0-9_]
-        return pagename.clean().replace(/[^\w\u00C0-\u1FFF\u2800-\uFFFD()&+,\-=.$ ]/g, "");
-
+        return pagename.clean().replace(/[^\w\u00C0-\u1FFF\u2800-\uFFFD()&+,\-=.$/ ]/g, "");
     },
 
     /*


### PR DESCRIPTION
### Summary
This pull request aims to resolve the issue described in [JSPWIKI-1181](https://issues.apache.org/jira/browse/JSPWIKI-1181). The problem was that the URLs generated for search results in quick navigation were incorrect when the page name contained a '/'. 

### Changes
- Updated the `cleanPageName` function to correctly handle the '/' character.


