### PR TITLE
Replace 'size() == 0' with 'isEmpty()'

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,12 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+**2023-10-12  Arturo Bernal (abernal AT apache DOT org)**
+
+* _2.12.2-git-07_
+
+Replaced 'size() == 0' with 'isEmpty()'
+
 *2023-10-08  Arturo Bernal (abernal AT apache DOT org)**
 
 * _2.12.2-git-06_

--- a/jspwiki-api/src/main/java/org/apache/wiki/api/Release.java
+++ b/jspwiki-api/src/main/java/org/apache/wiki/api/Release.java
@@ -69,7 +69,7 @@ public final class Release {
      *  <p>
      *  If the build identifier is empty, it is not added.
      */
-    public static final String     BUILD         = "06";
+    public static final String     BUILD         = "07";
 
     /**
      *  This is the generic version string you should use when printing out the version.  It is of

--- a/jspwiki-cache/src/main/java/org/apache/wiki/cache/EhcacheCachingManager.java
+++ b/jspwiki-cache/src/main/java/org/apache/wiki/cache/EhcacheCachingManager.java
@@ -54,7 +54,7 @@ public class EhcacheCachingManager implements CachingManager, Initializable {
     /** {@inheritDoc} */
     @Override
     public void shutdown() {
-        if( cacheMap.size() > 0 ) {
+        if(!cacheMap.isEmpty()) {
             CacheManager.getInstance().shutdown();
             cacheMap.clear();
             cacheStats.clear();

--- a/jspwiki-kendra-searchprovider/src/main/java/org/apache/wiki/search/kendra/KendraSearchProvider.java
+++ b/jspwiki-kendra-searchprovider/src/main/java/org/apache/wiki/search/kendra/KendraSearchProvider.java
@@ -145,7 +145,7 @@ public class KendraSearchProvider implements SearchProvider {
         final BatchDeleteDocumentRequest request = new BatchDeleteDocumentRequest().withIndexId( indexId )
                 .withDocumentIdList( pageName );
         final BatchDeleteDocumentResult result = getKendra().batchDeleteDocument( request );
-        if ( result.getFailedDocuments().size() == 0 ) {
+        if (result.getFailedDocuments().isEmpty()) {
             LOG.debug( format( "Page '%s' was removed from index", pageName ) );
         } else {
             LOG.error( format( "Failed to remove Page '%s' from index", pageName ) );
@@ -341,7 +341,7 @@ public class KendraSearchProvider implements SearchProvider {
         final String executionId = startExecution();
         synchronized ( updates ) {
             try {
-                while ( updates.size() > 0 ) {
+                while (!updates.isEmpty()) {
                     indexOnePage( updates.remove( 0 ), executionId );
                 }
             } finally {
@@ -384,7 +384,7 @@ public class KendraSearchProvider implements SearchProvider {
             final BatchPutDocumentRequest request = new BatchPutDocumentRequest().withIndexId( indexId )
                     .withDocuments( document );
             final BatchPutDocumentResult result = getKendra().batchPutDocument( request );
-            if ( result.getFailedDocuments().size() == 0 ) {
+            if (result.getFailedDocuments().isEmpty()) {
                 LOG.info( format( "Successfully indexed Page '%s' as %s", page.getName(), document.getContentType() ) );
             } else {
                 for ( final BatchPutDocumentResponseFailedDocument failedDocument : result.getFailedDocuments() ) {

--- a/jspwiki-main/src/main/java/org/apache/wiki/TranslationsCheck.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/TranslationsCheck.java
@@ -119,7 +119,7 @@ public class TranslationsCheck {
         System.out.println( "Duplicates overall (two or more occurences):" );
         System.out.println( "--------------------------------------------" );
         final Iterator< String > iter = duplProps.iterator();
-        if( duplProps.size() == 0 ) {
+        if(duplProps.isEmpty()) {
             System.out.println( "(none)" );
         } else {
             while( iter.hasNext() ) {

--- a/jspwiki-main/src/main/java/org/apache/wiki/WikiSession.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/WikiSession.java
@@ -196,7 +196,7 @@ public class WikiSession implements Session {
     @Override
     public String[] getMessages( final String topic ) {
         final Set< String > messages = m_messages.get( topic );
-        if( messages == null || messages.size() == 0 ) {
+        if( messages == null || messages.isEmpty()) {
             return new String[ 0 ];
         }
         return messages.toArray( new String[0] );

--- a/jspwiki-main/src/main/java/org/apache/wiki/attachment/AttachmentManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/attachment/AttachmentManager.java
@@ -148,7 +148,7 @@ public interface AttachmentManager {
      */
     default boolean hasAttachments( final Page wikipage ) {
         try {
-            return listAttachments( wikipage ).size() > 0;
+            return !listAttachments(wikipage).isEmpty();
         } catch( final Exception e ) {
             LogManager.getLogger( AttachmentManager.class ).info( e.getMessage(), e );
         }

--- a/jspwiki-main/src/main/java/org/apache/wiki/attachment/AttachmentServlet.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/attachment/AttachmentServlet.java
@@ -430,7 +430,7 @@ public class AttachmentServlet extends HttpServlet {
                 }
             }
 
-            if( fileItems.size() == 0 ) {
+            if(fileItems.isEmpty()) {
                 throw new RedirectException( "Broken file upload", errorPage );
 
             } else {

--- a/jspwiki-main/src/main/java/org/apache/wiki/auth/DefaultAuthenticationManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/auth/DefaultAuthenticationManager.java
@@ -168,12 +168,12 @@ public class DefaultAuthenticationManager implements AuthenticationManager {
 
             // Execute the container login module, then (if that fails) the cookie auth module
             Set< Principal > principals = authenticationMgr.doJAASLogin( WebContainerLoginModule.class, handler, options );
-            if ( principals.size() == 0 && authenticationMgr.allowsCookieAuthentication() ) {
+            if (principals.isEmpty() && authenticationMgr.allowsCookieAuthentication() ) {
                 principals = authenticationMgr.doJAASLogin( CookieAuthenticationLoginModule.class, handler, options );
             }
 
             // If the container logged the user in successfully, tell the Session (and add all the Principals)
-            if ( principals.size() > 0 ) {
+            if (!principals.isEmpty()) {
                 fireEvent( WikiSecurityEvent.LOGIN_AUTHENTICATED, getLoginPrincipal( principals ), session );
                 for( final Principal principal : principals ) {
                     fireEvent( WikiSecurityEvent.PRINCIPAL_ADD, principal, session );
@@ -188,7 +188,7 @@ public class DefaultAuthenticationManager implements AuthenticationManager {
         if ( !session.isAuthenticated() && authenticationMgr.allowsCookieAssertions() ) {
             // Execute the cookie assertion login module
             final Set< Principal > principals = authenticationMgr.doJAASLogin( CookieAssertionLoginModule.class, handler, options );
-            if ( principals.size() > 0 ) {
+            if (!principals.isEmpty()) {
                 fireEvent( WikiSecurityEvent.LOGIN_ASSERTED, getLoginPrincipal( principals ), session);
             }
         }
@@ -196,7 +196,7 @@ public class DefaultAuthenticationManager implements AuthenticationManager {
         // If user still anonymous, use the remote address
         if( session.isAnonymous() ) {
             final Set< Principal > principals = authenticationMgr.doJAASLogin( AnonymousLoginModule.class, handler, options );
-            if( principals.size() > 0 ) {
+            if(!principals.isEmpty()) {
                 fireEvent( WikiSecurityEvent.LOGIN_ANONYMOUS, getLoginPrincipal( principals ), session );
                 return true;
             }
@@ -225,7 +225,7 @@ public class DefaultAuthenticationManager implements AuthenticationManager {
 
         // Execute the user's specified login module
         final Set< Principal > principals = doJAASLogin( m_loginModuleClass, handler, m_loginModuleOptions );
-        if( principals.size() > 0 ) {
+        if(!principals.isEmpty()) {
             fireEvent(WikiSecurityEvent.LOGIN_AUTHENTICATED, getLoginPrincipal( principals ), session );
             for ( final Principal principal : principals ) {
                 fireEvent( WikiSecurityEvent.PRINCIPAL_ADD, principal, session );

--- a/jspwiki-main/src/main/java/org/apache/wiki/auth/SecurityVerifier.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/auth/SecurityVerifier.java
@@ -673,7 +673,7 @@ public final class SecurityVerifier {
             // Verify the file
             policy.read();
             final List<Exception> errors = policy.getMessages();
-            if ( errors.size() > 0 ) {
+            if (!errors.isEmpty()) {
                 for( final Exception e : errors ) {
                     m_session.addMessage( ERROR_POLICY, e.getMessage() );
                 }

--- a/jspwiki-main/src/main/java/org/apache/wiki/auth/authorize/WebContainerAuthorizer.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/auth/authorize/WebContainerAuthorizer.java
@@ -221,7 +221,7 @@ public class WebContainerAuthorizer implements WebAuthorizer  {
                                                   .evaluate( root );
 
         // If we can't find either one, we must not be constrained
-        if( constraints.size() == 0 ) {
+        if(constraints.isEmpty()) {
             return false;
         }
 
@@ -231,7 +231,7 @@ public class WebContainerAuthorizer implements WebAuthorizer  {
         }
 
         // If no roles, we must not be constrained
-        if( roles.size() == 0 ) {
+        if(roles.isEmpty()) {
             return false;
         }
 

--- a/jspwiki-main/src/main/java/org/apache/wiki/auth/login/AbstractLoginModule.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/auth/login/AbstractLoginModule.java
@@ -180,7 +180,7 @@ public abstract class AbstractLoginModule implements LoginModule {
      */
     private boolean succeeded()
     {
-        return m_principals.size() > 0;
+        return !m_principals.isEmpty();
     }
 
     /**

--- a/jspwiki-main/src/main/java/org/apache/wiki/auth/user/XMLUserDatabase.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/auth/user/XMLUserDatabase.java
@@ -414,7 +414,7 @@ public class XMLUserDatabase extends AbstractUserDatabase {
         }
 
         // Save the attributes as Base64 string
-        if( profile.getAttributes().size() > 0 ) {
+        if(!profile.getAttributes().isEmpty()) {
             try {
                 final String encodedAttributes = Serializer.serializeToBase64( profile.getAttributes() );
                 final Element attributes = c_dom.createElement( ATTRIBUTES_TAG );

--- a/jspwiki-main/src/main/java/org/apache/wiki/parser/JSPWikiMarkupParser.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/parser/JSPWikiMarkupParser.java
@@ -218,7 +218,7 @@ public class JSPWikiMarkupParser extends MarkupParser {
      *  @return The result of the mutation.
      */
     protected String callMutatorChain( final Collection< StringTransmutator > list, String text ) {
-        if( list == null || list.size() == 0 ) {
+        if( list == null || list.isEmpty()) {
             return text;
         }
 
@@ -1975,7 +1975,7 @@ public class JSPWikiMarkupParser extends MarkupParser {
             }
 
             //  If there were any elements, then add a new <p> (unless it would be an empty one)
-            if( ls.size() > 0 ) {
+            if(!ls.isEmpty()) {
                 final Element newel = new Element("p");
                 for( final Content c : ls ) {
                     c.detach();

--- a/jspwiki-main/src/main/java/org/apache/wiki/plugin/ListLocksPlugin.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/plugin/ListLocksPlugin.java
@@ -52,7 +52,7 @@ public class ListLocksPlugin implements Plugin {
         result.append( "<th>" ).append( rb.getString( "plugin.listlocks.page" ) ).append( "</th><th>" ).append( rb.getString( "plugin.listlocks.locked.by" ) ).append( "</th><th>" ).append( rb.getString( "plugin.listlocks.acquired" ) ).append( "</th><th>" ).append( rb.getString( "plugin.listlocks.expires" ) ).append( "</th>\n" );
         result.append("</tr>");
 
-        if( locks.size() == 0 ) {
+        if(locks.isEmpty()) {
             result.append( "<tr><td colspan=\"4\" class=\"odd\">" ).append( rb.getString( "plugin.listlocks.no.locks.exist" ) ).append( "</td></tr>\n" );
         } else {
             int rowNum = 1;

--- a/jspwiki-main/src/main/java/org/apache/wiki/plugin/PageViewPlugin.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/plugin/PageViewPlugin.java
@@ -369,7 +369,7 @@ public class PageViewPlugin extends AbstractReferralPlugin implements Plugin, In
                         }
                         result = counter.toString();
 
-                    } else if( body != null && 0 < body.length() && STR_LIST.equals( show ) ) {
+                    } else if( body != null && !body.isEmpty() && STR_LIST.equals( show ) ) {
                         // show list of counts
                         String header = STR_EMPTY;
                         String line = body;
@@ -461,7 +461,7 @@ public class PageViewPlugin extends AbstractReferralPlugin implements Plugin, In
          */
         private Pattern[] compileGlobs( final String name, final String value ) throws PluginException {
             Pattern[] result = null;
-            if( value != null && 0 < value.length() && !STR_GLOBSTAR.equals( value ) ) {
+            if( value != null && !value.isEmpty() && !STR_GLOBSTAR.equals( value ) ) {
                 try {
                     final PatternCompiler pc = new GlobCompiler();
                     final String[] ptrns = StringUtils.split( value, STR_COMMA );

--- a/jspwiki-main/src/main/java/org/apache/wiki/plugin/ReferringPagesPlugin.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/plugin/ReferringPagesPlugin.java
@@ -95,7 +95,7 @@ public class ReferringPagesPlugin extends AbstractReferralPlugin {
 
             LOG.debug( "Fetching referring pages for {} with a max of {}", page.getName(), items );
 
-            if( links != null && links.size() > 0 ) {
+            if( links != null && !links.isEmpty()) {
                 links = filterAndSortCollection( links );
                 wikitext = wikitizeCollection( links, m_separator, items );
 
@@ -116,7 +116,7 @@ public class ReferringPagesPlugin extends AbstractReferralPlugin {
             }
 
             // If nothing was left after filtering or during search
-            if( links == null || links.size() == 0 ) {
+            if( links == null || links.isEmpty()) {
                 wikitext = rb.getString( "referringpagesplugin.nobody" );
                 result.append( makeHTML( context, wikitext ) );
             } else  if( m_show.equals( PARAM_SHOW_VALUE_COUNT ) ) {

--- a/jspwiki-main/src/main/java/org/apache/wiki/plugin/UnusedPagesPlugin.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/plugin/UnusedPagesPlugin.java
@@ -62,7 +62,7 @@ public class UnusedPagesPlugin extends AbstractReferralPlugin {
         String wikitext;
         if( m_show.equals( PARAM_SHOW_VALUE_COUNT ) ) {
             wikitext = "" + links.size();
-            if( m_lastModified && links.size() != 0 ) {
+            if( m_lastModified && !links.isEmpty()) {
                 wikitext = links.size() + " (" + m_dateFormat.format( m_dateLastModified ) + ")";
             }
             return makeHTML( context, wikitext );

--- a/jspwiki-main/src/main/java/org/apache/wiki/plugin/WeblogArchivePlugin.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/plugin/WeblogArchivePlugin.java
@@ -80,7 +80,7 @@ public class WeblogArchivePlugin implements Plugin {
         //  Output proper HTML.
         sb.append( "<ul>\n" );
 
-        if( months.size() > 0 ) {
+        if(!months.isEmpty()) {
             year = ( months.iterator().next() ).get( Calendar.YEAR );
             sb.append( "<li class=\"archiveyear\">" ).append( year ).append( "</li>\n" );
         }

--- a/jspwiki-main/src/main/java/org/apache/wiki/references/DefaultReferenceManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/references/DefaultReferenceManager.java
@@ -369,7 +369,7 @@ public class DefaultReferenceManager extends BasePageFilter implements Reference
                 // new Set to avoid concurrency issues
                 final Set< Map.Entry < String, Object > > entries = new HashSet<>( p.getAttributes().entrySet() );
 
-                if( entries.size() == 0 ) {
+                if(entries.isEmpty()) {
                     //  Nothing to serialize, therefore we will just simply remove the serialization file so that the
                     //  next time we boot, we don't deserialize old data.
                     f.delete();

--- a/jspwiki-main/src/main/java/org/apache/wiki/search/LuceneSearchProvider.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/search/LuceneSearchProvider.java
@@ -569,7 +569,7 @@ public class LuceneSearchProvider implements SearchProvider {
             m_watchdog.enterState( "Emptying index queue", 60 );
 
             synchronized( m_provider.m_updates ) {
-                while( m_provider.m_updates.size() > 0 ) {
+                while(!m_provider.m_updates.isEmpty()) {
                     final Object[] pair = m_provider.m_updates.remove( 0 );
                     final Page page = ( Page )pair[ 0 ];
                     final String text = ( String )pair[ 1 ];

--- a/jspwiki-main/src/main/java/org/apache/wiki/tags/CookieTag.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/tags/CookieTag.java
@@ -355,7 +355,7 @@ public class CookieTag
     private String encodeValues(final Map<String, String> values )
     {
         final StringBuilder rval = new StringBuilder();
-        if( values == null || values.size() == 0 ) {
+        if( values == null || values.isEmpty()) {
             return rval.toString();
         }
 

--- a/jspwiki-main/src/main/java/org/apache/wiki/tags/IfNoSearchResultsTag.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/tags/IfNoSearchResultsTag.java
@@ -34,7 +34,7 @@ public class IfNoSearchResultsTag extends WikiTagBase {
     @Override
     public final int doWikiStartTag() throws IOException {
         final Collection< ? > list = (Collection< ? >)pageContext.getAttribute( "searchresults", PageContext.REQUEST_SCOPE );
-        if( list == null || list.size() == 0 ) {
+        if( list == null || list.isEmpty()) {
             return EVAL_BODY_INCLUDE;
         }
 

--- a/jspwiki-main/src/main/java/org/apache/wiki/tags/LinkTag.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/tags/LinkTag.java
@@ -262,7 +262,7 @@ public class LinkTag extends WikiLinkTag implements ParamHandler, BodyTag {
     }
 
     private String addParamsForRecipient( final String addTo, final Map< String, String > params ) {
-        if( params == null || params.size() == 0 ) {
+        if( params == null || params.isEmpty()) {
             return addTo;
         }
         final StringBuilder buf = new StringBuilder();

--- a/jspwiki-main/src/main/java/org/apache/wiki/tags/UserProfileTag.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/tags/UserProfileTag.java
@@ -175,7 +175,7 @@ public class UserProfileTag extends WikiTagBase {
         final ResourceBundle rb = Preferences.getBundle( context, InternationalizationManager.CORE_BUNDLE );
 
         tempRoles = Arrays.stream(roles).filter(role -> role instanceof GroupPrincipal).map(Principal::getName).collect(Collectors.toList());
-        if( tempRoles.size() == 0 ) {
+        if(tempRoles.isEmpty()) {
             return rb.getString( "userprofile.nogroups" );
         }
 
@@ -206,7 +206,7 @@ public class UserProfileTag extends WikiTagBase {
         final ResourceBundle rb = Preferences.getBundle( context, InternationalizationManager.CORE_BUNDLE );
 
         tempRoles = Arrays.stream(roles).filter(role -> role instanceof Role).map(Principal::getName).collect(Collectors.toList());
-        if( tempRoles.size() == 0 ) {
+        if(tempRoles.isEmpty()) {
             return rb.getString( "userprofile.noroles" );
         }
 

--- a/jspwiki-main/src/main/java/org/apache/wiki/ui/DefaultTemplateManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/ui/DefaultTemplateManager.java
@@ -231,7 +231,7 @@ public class DefaultTemplateManager extends BaseModuleManager implements Templat
         }
 
         /* fetch actual formats */
-        if( tfArr.size() == 0 )  {/* no props found - make sure some default formats are avail */
+        if(tfArr.isEmpty())  {/* no props found - make sure some default formats are avail */
             tfArr.add( "dd-MMM-yy" );
             tfArr.add( "d-MMM-yyyy" );
             tfArr.add( "EEE, dd-MMM-yyyy, zzzz" );

--- a/jspwiki-main/src/main/java/org/apache/wiki/ui/InputValidator.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/ui/InputValidator.java
@@ -160,7 +160,7 @@ public final class InputValidator {
      * @return <code>true</code> if <code>null</code> or blank (zero-length); <code>false</code> otherwise
      */
     public static boolean isBlank( final String input ) {
-        return input == null || input.trim().length() < 1;
+        return input == null || input.trim().isEmpty();
     }
 
 }

--- a/jspwiki-main/src/main/java/org/apache/wiki/ui/admin/beans/UserBean.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/ui/admin/beans/UserBean.java
@@ -76,7 +76,7 @@ public class UserBean extends SimpleAdminBean {
             return "";
         }
 
-        if( password != null && password.length() > 0 && !password.equals( password2 ) ) {
+        if( password != null && !password.isEmpty() && !password.equals( password2 ) ) {
             session.addMessage( "Passwords do not match!" );
             return "";
         }

--- a/jspwiki-main/src/main/java/org/apache/wiki/workflow/DefaultWorkflowManager.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/workflow/DefaultWorkflowManager.java
@@ -121,7 +121,7 @@ public class DefaultWorkflowManager implements WorkflowManager, Serializable {
             if( prop.startsWith( PROPERTY_APPROVER_PREFIX ) ) {
                 // For the key, everything after the prefix is the workflow name
                 final String key = prop.substring( PROPERTY_APPROVER_PREFIX.length() );
-                if( key.length() > 0 ) {
+                if(!key.isEmpty()) {
                     // Only use non-null/non-blank approvers
                     final String approver = props.getProperty( prop );
                     if( approver != null && !approver.isEmpty() ) {

--- a/jspwiki-util/src/main/java/org/apache/wiki/util/ClassUtil.java
+++ b/jspwiki-util/src/main/java/org/apache/wiki/util/ClassUtil.java
@@ -130,7 +130,7 @@ public final class ClassUtil {
     private static ClassLoader setupClassLoader( final List< String > externaljars) {
         classLoaderSetup = true;
         LOG.info( "setting up classloaders for external (plugin) jars" );
-        if( externaljars.size() == 0 ) {
+        if(externaljars.isEmpty()) {
             LOG.info( "no external jars configured, using standard classloading" );
             return ClassUtil.class.getClassLoader();
         }

--- a/jspwiki-util/src/main/java/org/apache/wiki/util/FormUtil.java
+++ b/jspwiki-util/src/main/java/org/apache/wiki/util/FormUtil.java
@@ -91,8 +91,8 @@ public final class FormUtil
     public static List< ? > getNumberedValues(final Map< ?, ? > params, final String keyPrefix )
     {
         final ArrayList<Object> rval = new ArrayList<>();
-        if( params == null || 
-            params.size() == 0 || 
+        if( params == null ||
+                params.isEmpty() ||
             keyPrefix == null || 
             keyPrefix.isEmpty() )
             return rval;

--- a/jspwiki-util/src/main/java/org/apache/wiki/util/XmlUtil.java
+++ b/jspwiki-util/src/main/java/org/apache/wiki/util/XmlUtil.java
@@ -132,7 +132,7 @@ public final class XmlUtil  {
 
 	public static Element getXPathElement( final Element base, final String expression ) {
 		final List< ? > nodes = XPathFactory.instance().compile( expression ).evaluate( base );
-		if( nodes == null || nodes.size() == 0 ) {
+		if( nodes == null || nodes.isEmpty()) {
 			return null;
 		} else {
 			return ( Element )nodes.get( 0 );

--- a/jspwiki-war/src/main/webapp/Comment.jsp
+++ b/jspwiki-war/src/main/webapp/Comment.jsp
@@ -120,7 +120,7 @@
     if( author == null ) {
         author = storedUser;
     }
-    if( author == null || author.length() == 0 ) {
+    if( author == null || author.isEmpty()) {
         author = StringUtils.capitalize( rb.getString( "varmgr.anonymous" ) );
     }
 
@@ -206,9 +206,9 @@
         pageText.append( commentText );
 
         log.debug("Author name ="+author);
-        if( author != null && author.length() > 0 ) {
+        if( author != null && !author.isEmpty()) {
             String signature = author;
-            if( link != null && link.length() > 0 ) {
+            if( link != null && !link.isEmpty()) {
                 link = HttpUtil.guessValidURI( link );
                 signature = "["+author+"|"+link+"]";
             }

--- a/jspwiki-war/src/main/webapp/Edit.jsp
+++ b/jspwiki-war/src/main/webapp/Edit.jsp
@@ -156,7 +156,7 @@
 
         session.removeAttribute("changenote");
 
-        if( changenote != null && changenote.length() > 0 ) {
+        if( changenote != null && !changenote.isEmpty()) {
             modifiedPage.setAttribute( Page.CHANGENOTE, changenote );
         } else {
             modifiedPage.removeAttribute( Page.CHANGENOTE );

--- a/jspwiki-war/src/main/webapp/Error.jsp
+++ b/jspwiki-war/src/main/webapp/Error.jsp
@@ -41,7 +41,7 @@
     Throwable realcause = null;
 
     msg = exception.getMessage();
-    if( msg == null || msg.length() == 0 )
+    if( msg == null || msg.isEmpty())
     {
         msg = "An unknown exception "+exception.getClass().getName()+" was caught by Error.jsp.";
     }

--- a/jspwiki-war/src/main/webapp/Rename.jsp
+++ b/jspwiki-war/src/main/webapp/Rename.jsp
@@ -67,7 +67,7 @@
     Session wikiSession = wikiContext.getWikiSession();
     try
     {
-        if (renameTo.length() > 0)
+        if (!renameTo.isEmpty())
         {
             String renamedTo = wiki.getManager( PageRenamer.class ).renamePage(wikiContext, renameFrom, renameTo, changeReferences);
 

--- a/jspwiki-war/src/main/webapp/Search.jsp
+++ b/jspwiki-war/src/main/webapp/Search.jsp
@@ -66,7 +66,7 @@
         //  Did the user click on "go"?
         //
         if( go != null ) {
-            if( list != null && list.size() > 0 ) {
+            if( list != null && !list.isEmpty()) {
                 SearchResult sr = list.iterator().next();
                 Page wikiPage = sr.getPage();
                 String url = wikiContext.getViewURL( wikiPage.getName() );

--- a/jspwiki-war/src/main/webapp/rss.jsp
+++ b/jspwiki-war/src/main/webapp/rss.jsp
@@ -118,7 +118,7 @@
         if( p.getLastModified().after( latest ) ) latest = p.getLastModified();
     }
 
-    if( !hasChanged && changed.size() > 0 ) {
+    if( !hasChanged && !changed.isEmpty()) {
         response.sendError( HttpServletResponse.SC_NOT_MODIFIED );
         w.exitState();
         return;

--- a/jspwiki-war/src/main/webapp/templates/210/InfoContent.jsp
+++ b/jspwiki-war/src/main/webapp/templates/210/InfoContent.jsp
@@ -51,7 +51,7 @@
   {
     creationAuthor = firstPage.getAuthor();
 
-    if( creationAuthor != null && creationAuthor.length() > 0 )
+    if( creationAuthor != null && !creationAuthor.isEmpty())
     {
       creationAuthor = TextUtil.replaceEntities(creationAuthor);
     }

--- a/jspwiki-war/src/main/webapp/templates/default/InfoContent.jsp
+++ b/jspwiki-war/src/main/webapp/templates/default/InfoContent.jsp
@@ -49,7 +49,7 @@
   {
     creationAuthor = firstPage.getAuthor();
 
-    if( creationAuthor != null && creationAuthor.length() > 0 )
+    if( creationAuthor != null && !creationAuthor.isEmpty())
     {
       creationAuthor = TextUtil.replaceEntities(creationAuthor);
     }


### PR DESCRIPTION
This commit replaces instances of 'size() == 0' with 'isEmpty()' in relevant code files. The change is aimed at:

1. Improving code readability: 'isEmpty()' is more expressive and clearly indicates the intent.
2. Enhancing performance: 'isEmpty()' is generally an O(1) operation, whereas 'size() == 0' can be O(n) for some data structures.

This is an internal code optimization and does not affect the external API or functionality.
