### PR TITLE
Update URLConstructor.java

### DIFF
--- a/jspwiki-main/src/main/java/org/apache/wiki/url/URLConstructor.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/url/URLConstructor.java
@@ -77,7 +77,7 @@ public interface URLConstructor extends Initializable {
     static String parsePageFromURL( final HttpServletRequest request, final Charset encoding ) {
         final String name = request.getPathInfo();
         if( name == null || name.length() <= 1 ) {
-            return null;
+            return request.getParameter("page");
         } else if( name.charAt(0) == '/' ) {
             return name.substring(1);
         }


### PR DESCRIPTION
The method didn't work for the default URL style, causing PAGE_REQUESTED and PAGE_DELIVERED events to have a null page name.