### PR TITLE
JSPWIKI-1190 syntax converter command line util

### DIFF
--- a/jspwiki-main/pom.xml
+++ b/jspwiki-main/pom.xml
@@ -325,6 +325,18 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.4.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/jspwiki-markdown/pom.xml
+++ b/jspwiki-markdown/pom.xml
@@ -154,6 +154,18 @@
           </execution>
         </executions>
       </plugin>
+       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.4.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/jspwiki-syntax-converter/pom.xml
+++ b/jspwiki-syntax-converter/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.jspwiki</groupId>
+        <artifactId>jspwiki-builder</artifactId>
+        <version>2.12.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>jspwiki-syntax-converter</artifactId>
+    <name>Apache JSPWiki syntax converter</name>
+    <packaging>jar</packaging>
+    <properties>
+        <exec.mainClass>org.apache.wiki.markdown.migration.Main</exec.mainClass>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jspwiki-markdown</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jspwiki-markdown</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jspwiki-main</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jspwiki-main</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+        </dependency>
+         <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      
+    </dependency>
+
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      
+    </dependency>
+
+    <dependency>
+      <groupId>net.sourceforge.stripes</groupId>
+      <artifactId>stripes</artifactId>
+      
+    </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>${exec.mainClass}</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                        <phase>package</phase> <!-- bind to the packaging phase -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/jspwiki-syntax-converter/src/main/java/org/apache/wiki/markdown/migration/Main.java
+++ b/jspwiki-syntax-converter/src/main/java/org/apache/wiki/markdown/migration/Main.java
@@ -1,0 +1,130 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+ */
+package org.apache.wiki.markdown.migration;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+
+/**
+ * Main entry point for the converter. It's basically a void main that calls a
+ * unit test function that performs the conversion. Use -help to get syntax
+ * info.
+ *
+ * @author AO
+ */
+public class Main {
+
+    public static void main(String[] args) throws Exception {
+        Options options = new Options();
+        options.addOption("srcDir", true, "Source directory");
+        options.addOption("destDir", true, "Destination directory");
+        options.addOption("srcFormat", true, "Source format (jspwiki,markdown)");
+        options.addOption("destFormat", true, "Destination format (jspwiki,markdown)");
+        options.addOption("r", false, "Recursive (process history too)");
+        CommandLineParser parser = new DefaultParser();
+        CommandLine cmd = parser.parse(options, args);
+        int pts = 0;
+        if (cmd.hasOption("srcDir")) {
+            pts++;
+        }
+        if (cmd.hasOption("destDir")) {
+            pts++;
+        }
+        if (cmd.hasOption("srcFormat")) {
+            pts++;
+        }
+        if (cmd.hasOption("destFormat")) {
+            pts++;
+        }
+        if (pts != 4) {
+            HelpFormatter formatter = new HelpFormatter();
+            formatter.printHelp("jspwiki-syntax-converter", options);
+            return;
+        }
+        //confirm both direcotires exist
+        File src = new File(cmd.getOptionValue("srcDir"));
+        if (!src.exists()) {
+            System.err.println("srcDir does not exist");
+            return;
+        } else {
+            if (!src.isDirectory()) {
+                System.err.println("srcDir was not a directory");
+                return;
+            }
+        }
+        File dest = new File(cmd.getOptionValue("destDir"));
+        if (!dest.exists()) {
+            if (!dest.mkdirs()) {
+                System.err.println("destDir does not exist and we failed to mkdirs at that location. Try a different path");
+                return;
+            }
+        } else {
+            System.out.println("destDir exists. Any existing files may be overwritten");
+        }
+        long start = System.currentTimeMillis();
+        WikiSyntaxConverter converter = new WikiSyntaxConverter();
+        List<String> errors = convert(converter, src,
+                cmd.getOptionValue("srcFormat"),
+                dest, cmd.getOptionValue("destFormat"),
+                cmd.hasOption("r")
+        );
+        System.out.println("processed in " + (System.currentTimeMillis() - start) + "ms with " + errors.size() + " errors");
+        for (String s : errors) {
+            System.out.println(s);
+        }
+        if (errors.isEmpty()) {
+            return;
+        } else {
+            System.exit(1);
+        }
+    }
+
+    private static List<String> convert(WikiSyntaxConverter converter, File src, String srcF, File dest, String destF, boolean recursive) throws Exception {
+        System.out.println("processing " + src.getAbsolutePath());
+        List<String> r = new ArrayList<>();
+        r.addAll(converter.convert(src.getAbsolutePath(), srcF, dest.getAbsolutePath(), destF));
+        if (!recursive) {
+            return Collections.EMPTY_LIST;
+        }
+        File[] files = src.listFiles();
+        if (files == null) {
+            return Collections.EMPTY_LIST;
+        }
+
+        for (File f : files) {
+            if (!f.isDirectory()) {
+                continue;
+            }
+            File newDest = new File(destF, f.getName());
+            if (!newDest.mkdirs()) {
+                System.err.println("failed to mkdirs at " + newDest.getAbsolutePath());
+            }
+            r.addAll(convert(converter, f, srcF, newDest, destF, recursive));
+        }
+        return r;
+    }
+
+}

--- a/jspwiki-syntax-converter/src/main/java/org/apache/wiki/markdown/migration/Main.java
+++ b/jspwiki-syntax-converter/src/main/java/org/apache/wiki/markdown/migration/Main.java
@@ -33,7 +33,6 @@ import org.apache.commons.cli.Options;
  * unit test function that performs the conversion. Use -help to get syntax
  * info.
  *
- * @author AO
  */
 public class Main {
 

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@
     <module>jspwiki-portable</module>
     <module>jspwiki-it-tests</module><!-- IT tests are launched only if -Pintegration-tests is given -->
     <module>jspwiki-bom</module>
+    <module>jspwiki-syntax-converter</module>
   </modules>
 
   <dependencyManagement> <!-- defines what configuration is going to be used if, and only if, the dependency is used -->


### PR DESCRIPTION
initial cut at building a command line utility for the syntax converter. It still needs some packaging work to include this in the distributable. Pushing this for review. I'm not clear if markdown to jspwiki is a supported path or not. or jspwiki to any other format. also not clear if it's a good idea to clone the entire wiki storage directory during the conversion. Might be helpful for manual review, or for switching over, verifying, and rolling back in necessary etc.