### PR TITLE
Fix problematic CalendarTag <-> WeblogPlugin interaction

### DIFF
--- a/jspwiki-main/src/main/java/org/apache/wiki/tags/CalendarTag.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/tags/CalendarTag.java
@@ -40,8 +40,7 @@ import java.util.Date;
  *  Provides a nice calendar.  Responds to the following HTTP parameters:
  *  <ul>
  *  <li>calendar.date - If this parameter exists, then the calendar
- *  date is taken from the month and year.  The date must be in ddMMyy
- *  format.
+ *  date is taken from the month and year.  The date must be in ddMMyy format.
  *  <li>weblog.startDate - If calendar.date parameter does not exist,
  *  we then check this date.
  *  </ul>
@@ -57,7 +56,7 @@ public class CalendarTag extends WikiTagBase {
 
     private static final long serialVersionUID = 0L;
     private static final Logger LOG = LogManager.getLogger( CalendarTag.class );
-    private static final int NUM_PAGES_TO_CHECK = 5;
+    private static final int NUM_PAGES_TO_CHECK = 3;
     
     private SimpleDateFormat m_pageFormat;
     private SimpleDateFormat m_urlFormat;
@@ -161,19 +160,19 @@ public class CalendarTag extends WikiTagBase {
         if( m_pageFormat != null ) {
             final String pagename = m_pageFormat.format( day.getTime() );
 
-			var somePageExistsOnThisDay = false;
-			if (m_addIndex) {
-				// Look at up to 5 pages for whether the page exists. This avoids an issue 
-				// with the WeblogPlugin when the first blog post(s) of a day gets deleted.
-				for (int pageIdx = 1; pageIdx <= NUM_PAGES_TO_CHECK; pageIdx++) {
-					if( engine.getManager( PageManager.class ).wikiPageExists( pagename+pageIdx ) ) {
-						somePageExistsOnThisDay = true;
-						break;
-					}
-				}
-			} else {
-				somePageExistsOnThisDay = engine.getManager( PageManager.class ).wikiPageExists( pagename );
-			}
+            var somePageExistsOnThisDay = false;
+            if (m_addIndex) {
+                // Look at up to 3 pages for whether the page exists. This avoids an issue 
+                // with the WeblogPlugin when the first blog post(s) of a day gets deleted.
+		    for (int pageIdx = 1; pageIdx <= NUM_PAGES_TO_CHECK; pageIdx++) {
+                        if( engine.getManager( PageManager.class ).wikiPageExists( pagename+pageIdx ) ) {
+                            somePageExistsOnThisDay = true;
+                            break;
+                        }
+                }
+            } else {
+                somePageExistsOnThisDay = engine.getManager( PageManager.class ).wikiPageExists( pagename );
+            }
 
             if( somePageExistsOnThisDay ) {
                 if( m_urlFormat != null ) {

--- a/jspwiki-main/src/main/resources/META-INF/jspwiki.tld
+++ b/jspwiki-main/src/main/resources/META-INF/jspwiki.tld
@@ -97,6 +97,10 @@
        <name>monthurlformat</name>
        <rtexprvalue>true</rtexprvalue>
     </attribute>
+    <attribute>
+       <name>addindex</name>
+       <rtexprvalue>true</rtexprvalue>
+    </attribute>
   </tag>
 
   <tag>

--- a/jspwiki-war/src/main/webapp/templates/default/Sidebar.jsp
+++ b/jspwiki-war/src/main/webapp/templates/default/Sidebar.jsp
@@ -29,7 +29,7 @@
 
   <c:set var="isweblog"><%= ( String )Context.findContext( pageContext ).getPage().getAttribute( /*ATTR_ISWEBLOG*/ "weblogplugin.isweblog" ) %></c:set>
   <c:if test="${isweblog}">
-  <wiki:Calendar pageformat="'${param.page}_blogentry_'ddMMyy'_1'"
+  <wiki:Calendar pageformat="'${param.page}_blogentry_'ddMMyy'_'" addindex="true"
                  urlformat="'Wiki.jsp?page=${param.page}&weblog.startDate='ddMMyy'&weblog.days=1'"/>
   </c:if>
 


### PR DESCRIPTION
As discussed recently on the mailing list, CalendarTag fails to link to a day that does have blog entries if the very first entry got deleted. This patch works around that by allowing for up to 3 blog entries (the pages with the ..._1, ..._2 and ..._3 endings) to have been deleted, and will still detect the 4th one. This number can be configured using the CalendarTag.NUM_PAGES_TO_CHECK constant.