### PR TITLE
getAllPages() returns all pages after cache ttl has expired

### DIFF
--- a/jspwiki-cache/src/main/java/org/apache/wiki/cache/CachingManager.java
+++ b/jspwiki-cache/src/main/java/org/apache/wiki/cache/CachingManager.java
@@ -19,6 +19,7 @@
 package org.apache.wiki.cache;
 
 
+import net.sf.ehcache.event.CacheEventListener;
 import org.apache.wiki.util.CheckedSupplier;
 
 import java.io.Serializable;
@@ -121,4 +122,12 @@ public interface CachingManager {
      */
     void remove( String cacheName, Serializable key );
 
+    /**
+     * Register a listener to a cache
+     *
+     * @param cacheName The cache to which the listener should be registered
+     * @param listener cache listener to register
+     * @return true if the listener is being added and was not already added
+     */
+    boolean registerListener( String cacheName, CacheEventListener listener );
 }

--- a/jspwiki-cache/src/main/java/org/apache/wiki/cache/EhcacheCachingManager.java
+++ b/jspwiki-cache/src/main/java/org/apache/wiki/cache/EhcacheCachingManager.java
@@ -21,6 +21,7 @@ package org.apache.wiki.cache;
 import net.sf.ehcache.Cache;
 import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.Element;
+import net.sf.ehcache.event.CacheEventListener;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.wiki.api.core.Engine;
@@ -158,6 +159,16 @@ public class EhcacheCachingManager implements CachingManager, Initializable {
             cacheMap.get( cacheName ).remove( key );
         }
     }
+
+	@Override
+	public boolean registerListener( final String cacheName, final CacheEventListener listener ) {
+		if (enabled(cacheName)) {
+			return cacheMap.get(cacheName).getCacheEventNotificationService().registerListener(listener);
+		}
+		return false;
+	}
+
+
 
     boolean keyAndCacheAreNotNull( final String cacheName, final Serializable key ) {
         return enabled( cacheName ) && key != null;

--- a/jspwiki-main/src/main/java/org/apache/wiki/providers/CachingProvider.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/providers/CachingProvider.java
@@ -18,6 +18,9 @@
  */
 package org.apache.wiki.providers;
 
+import net.sf.ehcache.Ehcache;
+import net.sf.ehcache.Element;
+import net.sf.ehcache.event.CacheEventListenerAdapter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.wiki.api.core.Context;
@@ -67,7 +70,7 @@ public class CachingProvider implements PageProvider {
     private PageProvider provider;
     private Engine engine;
 
-    private boolean allRequested;
+    private volatile boolean allRequested;
     private final AtomicLong pages = new AtomicLong( 0L );
 
     /**
@@ -80,6 +83,12 @@ public class CachingProvider implements PageProvider {
         // engine is used for getting the search engine
         this.engine = engine;
         cachingManager = this.engine.getManager( CachingManager.class );
+        cachingManager.registerListener(  CachingManager.CACHE_PAGES, new CacheEventListenerAdapter() {
+            @Override
+            public void notifyElementExpired(Ehcache cache, Element element) {
+                allRequested = false; // signal that the cache no longer contains all elements...
+            }
+        });
 
         //  Find and initialize real provider.
         final String classname;


### PR DESCRIPTION
Using cachingProvider.getAllPages() will be incomplete if the cache is configured so the entries expire over time. Pages in the cache will be evicted, but the allRequested-flag remains set to true.
To solve this, I registered a listener resetting the flag as soon as the first element expires. To be able to register listener, I also had to slightly extend the CachingManager...