### PR TITLE
[SECURITY][XBOW-024-109] Fix XSS vulnerability in header link rendering

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,16 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+**2024-12-24  Arturo Bernal (abernal AT apache DOT org)**
+
+* _2.12.3-git-04_
+
+* Fix for [SECURITY][DISCUSS] XBOW-024-109 XSS in JSPWiki Header Link Name
+  * Addressed XSS vulnerability in JSPWiki header link name by ensuring proper HTML escaping when `jspwiki.translatorReader.allowHTML` is disabled.
+  * Fixed markdown module to respect `jspwiki.translatorReader.allowHTML` property, preventing XSS in markdown syntax.
+  * Changes include improved input sanitization and added appropriate tests for validation.
+
+
 **2024-12-19  Juan Pablo Santos (juanpablo AT apache DOT org)**
 
 * _2.12.3-git-03_

--- a/jspwiki-api/src/main/java/org/apache/wiki/api/Release.java
+++ b/jspwiki-api/src/main/java/org/apache/wiki/api/Release.java
@@ -69,7 +69,7 @@ public final class Release {
      *  <p>
      *  If the build identifier is empty, it is not added.
      */
-    public static final String     BUILD         = "03";
+    public static final String     BUILD         = "04";
 
     /**
      *  This is the generic version string you should use when printing out the version.  It is of

--- a/jspwiki-main/src/main/java/org/apache/wiki/parser/JSPWikiMarkupParser.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/parser/JSPWikiMarkupParser.java
@@ -1,4 +1,4 @@
-/*
+    /*
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
     distributed with this work for additional information
@@ -298,7 +298,11 @@ public class JSPWikiMarkupParser extends MarkupParser {
             case LOCAL:
                 el = new Element( "a" ).setAttribute( "class", CLASS_FOOTNOTE );
                 el.setAttribute( "name", "ref-" + m_context.getName() + "-" + link.substring( 1 ) );
-                el.addContent( "[" + text + "]" );
+                if( !m_allowHTML ) {
+                    el.addContent( "[" + escapeHTMLEntities( text ) + "]" );
+                } else {
+                    el.addContent( "[" + text + "]" );
+                }
                 break;
 
                 //  With the image, external and interwiki types we need to make sure nobody can put in Javascript or

--- a/jspwiki-main/src/test/java/org/apache/wiki/parser/JSPWikiMarkupParserTest.java
+++ b/jspwiki-main/src/test/java/org/apache/wiki/parser/JSPWikiMarkupParserTest.java
@@ -1947,4 +1947,32 @@ public class JSPWikiMarkupParserTest {
                     "----\n" +
                     "author: [Asser], [Ebu], [JanneJalkanen], [Jarmo|mailto:jarmo@regex.com.au]\n";
 
+
+    @Test
+    public void testEscapeHTMLWhenHTMLNotAllowed() throws Exception {
+        final String src = "This should be a [#1 <script>alert('XSS')</script>]";
+        testEngine = TestEngine.build(with("jspwiki.translatorReader.allowHTML", "false")); // Disable HTML
+        final Page page = Wiki.contents().page(testEngine, PAGE_NAME);
+        final String output = translate(testEngine, page, src);
+        Assertions.assertEquals(
+                "This should be a <a class=\"footnote\" name=\"ref-testpage-1 &lt;script&gt;alert('XSS')&lt;/script&gt;\">[#1 &lt;script&gt;alert('XSS')&lt;/script&gt;]</a>",
+                output
+        );
+    }
+
+
+    @Test
+    public void testNoEscapeHTMLWhenHTMLAllowed() throws Exception {
+        final String src = "This should be a [#1 <b>bold</b>]";
+        testEngine = TestEngine.build(with("jspwiki.translatorReader.allowHTML", "true")); // Enable HTML
+        final Page page = Wiki.contents().page(testEngine, PAGE_NAME);
+        final String output = translate(testEngine, page, src);
+        Assertions.assertEquals(
+                "This should be a <a class=\"footnote\" name=\"ref-testpage-1 &lt;b&gt;bold&lt;/b&gt;\">[#1 <b>bold</b>]</a>",
+                output
+        );
+    }
+
+
+
 }

--- a/jspwiki-markdown/src/main/java/org/apache/wiki/parser/markdown/MarkdownDocument.java
+++ b/jspwiki-markdown/src/main/java/org/apache/wiki/parser/markdown/MarkdownDocument.java
@@ -23,6 +23,7 @@ import com.vladsch.flexmark.ext.definition.DefinitionExtension;
 import com.vladsch.flexmark.ext.footnotes.FootnoteExtension;
 import com.vladsch.flexmark.ext.tables.TablesExtension;
 import com.vladsch.flexmark.ext.toc.TocExtension;
+import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.parser.Parser;
 import com.vladsch.flexmark.parser.ParserEmulationProfile;
 import com.vladsch.flexmark.util.ast.Node;
@@ -33,6 +34,7 @@ import org.apache.wiki.api.core.Context;
 import org.apache.wiki.api.core.Page;
 import org.apache.wiki.markdown.MarkdownForJSPWikiExtension;
 import org.apache.wiki.parser.JSPWikiMarkupParser;
+import org.apache.wiki.parser.MarkupParser;
 import org.apache.wiki.parser.WikiDocument;
 
 import java.util.Arrays;
@@ -69,6 +71,7 @@ public class MarkdownDocument extends WikiDocument {
         options.set( AttributesExtension.ASSIGN_TEXT_ATTRIBUTES, true );
         // align style of Markdown's footnotes extension with jspwiki footnotes refs
         options.set( FootnoteExtension.FOOTNOTE_LINK_REF_CLASS, JSPWikiMarkupParser.CLASS_FOOTNOTE_REF );
+        options.set( HtmlRenderer.ESCAPE_HTML, context.getBooleanWikiProperty( MarkupParser.PROP_ALLOWHTML, false));
         options.set( Parser.EXTENSIONS, Arrays.asList( new Extension[] { new MarkdownForJSPWikiExtension( context, isImageInlining, inlineImagePatterns ),
                                                                          AttributesExtension.create(),
                                                                          DefinitionExtension.create(),


### PR DESCRIPTION
- Tightened footnote parsing in `JSPWikiMarkupParser`:
  * When `m_allowHTML` is false, added HTML entity escaping for footnote link text.
- Added support in `MarkdownDocument` to honor `jspwiki.translatorReader.allowHTML` property:
  * Set `HtmlRenderer.ESCAPE_HTML` option based on the property value.

These changes mitigate the XSS vulnerability identified in XBOW-024-109, ensuring safer input handling for both JSPWiki Core and Markdown modules.