### PR TITLE
Fix StringIndexOutOfBoundsException

### DIFF
--- a/jspwiki-main/src/main/java/org/apache/wiki/ajax/AjaxUtil.java
+++ b/jspwiki-main/src/main/java/org/apache/wiki/ajax/AjaxUtil.java
@@ -62,6 +62,11 @@ public class AjaxUtil extends HttpServlet {
         if( StringUtils.isBlank( path ) ) {
 			return null;
 		}
+		
+                // if this is true, there's nothing left to be done
+                if (path.endsWith(lastPart))
+                        return lastPart;
+
 		if( !lastPart.endsWith( "/" ) ) {
 			lastPart += "/";
 		}


### PR DESCRIPTION
On Tomcat 9, this call causes an exception for "/ajax/users" and "users" (in the Users tab in Admin.jsp). I haven't checked other servlet containers.

I'm not sure if this is the right fix, but it does make it work for me.